### PR TITLE
Initial Iteration of Elastic Search Api for alphabetical Search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>search.api.ch.gov.uk</artifactId>
-    <version>b5c2fef</version>
+    <version>unversioned</version>
     <name>search-api</name>
     <description>Search API to handle requests to Elastic Search data</description>
 

--- a/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.search.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SearchApiApplication {
+
+    private static final String APPLICATION_NAME_SPACE = "search.api.ch.gov.uk";
+
+    public static void main(String[] args) {
+        SpringApplication.run(SearchApiApplication.class, args);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfig.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfig.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.search.api.config;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticSearchConfig {
+
+    @Bean(destroyMethod = "close")
+    public RestHighLevelClient client() {
+        return new RestHighLevelClient(
+            RestClient.builder(
+                new HttpHost("es7-search-server1-shaun.aws.chdev.org", 9200, "http")));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.search.api.controller.search;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.service.SearchIndexService;
+
+@Controller
+@RequestMapping(value = "/alphabeticalSearch")
+public class AlphabeticalSearchController {
+
+    @Autowired
+    private SearchIndexService searchIndexService;
+
+    @Autowired
+    private ApiToResponseMapper apiToResponseMapper;
+
+
+    @GetMapping("/corporateName")
+    public ResponseEntity searchByCorporateName(
+        @RequestParam(name = "corporateName") String corporateName) {
+
+        ResponseObject responseObject = searchIndexService.search(corporateName);
+
+        return apiToResponseMapper.map(responseObject);
+
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
@@ -28,7 +28,5 @@ public class AlphabeticalSearchController {
         ResponseObject responseObject = searchIndexService.search(corporateName);
 
         return apiToResponseMapper.map(responseObject);
-
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -1,9 +1,12 @@
 package uk.gov.companieshouse.search.api.mapper;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Component
 public class ApiToResponseMapper {
@@ -12,11 +15,11 @@ public class ApiToResponseMapper {
 
         switch(responseObject.getStatus()) {
             case SEARCH_FOUND:
-                return ResponseEntity.status(HttpStatus.FOUND).body(responseObject.getData());
+                return ResponseEntity.status(FOUND).body(responseObject.getData());
             case SEARCH_NOT_FOUND:
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+                return ResponseEntity.status(NOT_FOUND).build();
             default:
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+                return ResponseEntity.status(INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.search.api.mapper;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+
+@Component
+public class ApiToResponseMapper {
+
+    public ResponseEntity map(ResponseObject responseObject) {
+
+        switch(responseObject.getStatus()) {
+            case SEARCH_FOUND:
+                return ResponseEntity.status(HttpStatus.FOUND).body(responseObject.getData());
+            case SEARCH_NOT_FOUND:
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            default:
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/Company/Company.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/Company/Company.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.search.api.model.Company;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Company {
+
+    @JsonProperty("items")
+    private Items items;
+
+    public Company() { }
+
+    public Company(Items items) {
+        this.items = items;
+    }
+
+    public Items getItems() {
+        return items;
+    }
+
+    public void setItems(Items items) {
+        this.items = items;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/Company/Items.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/Company/Items.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.search.api.model.Company;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Items {
+
+    @JsonProperty("company_number")
+    private String companyNumber;
+    @JsonProperty("company_status")
+    private String companyStatus;
+    @JsonProperty("corporateName")
+    private String corporateName;
+
+    public Items() {}
+
+    public Items(String companyNumber, String companyStatus, String corporateName) {
+        this.companyNumber = companyNumber;
+        this.companyStatus = companyStatus;
+        this.corporateName = corporateName;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public String getCompanyStatus() {
+        return companyStatus;
+    }
+
+    public void setCompanyStatus(String companyStatus) {
+        this.companyStatus = companyStatus;
+    }
+
+    public String getCorporateName() {
+        return corporateName;
+    }
+
+    public void setCorporateName(String corporateName) {
+        this.corporateName = corporateName;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/SearchResults.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/SearchResults.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.search.api.model;
+
+import com.google.gson.Gson;
+
+import java.util.List;
+
+public class SearchResults<T> {
+
+    private String searchType;
+
+    private List<T> searchResults;
+
+    public SearchResults() {
+    }
+
+    public SearchResults(String searchType, List<T> searchResults) {
+        this.searchType = searchType;
+        this.searchResults = searchResults;
+    }
+
+    public String getSearchType() {
+        return searchType;
+    }
+
+    public void setSearchType(String searchType) {
+        this.searchType = searchType;
+    }
+
+    public List<T> getSearchResults() {
+        return searchResults;
+    }
+
+    public void setSearchResults(List<T> searchResults) {
+        this.searchResults = searchResults;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseObject.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseObject.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.search.api.model.response;
+
+import com.google.gson.Gson;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+
+public class ResponseObject {
+
+    private ResponseStatus status;
+
+    private SearchResults searchResults;
+
+    public ResponseObject(ResponseStatus status) {
+        this.status = status;
+    }
+
+    public ResponseObject(ResponseStatus status, SearchResults searchResults) {
+        this.status = status;
+        this.searchResults = searchResults;
+    }
+
+    public ResponseStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ResponseStatus status) {
+        this.status = status;
+    }
+
+    public SearchResults getData() {
+        return searchResults;
+    }
+
+    public void setData(SearchResults searchResults) {
+        this.searchResults = searchResults;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseStatus.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseStatus.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.search.api.model.response;
+
+public enum ResponseStatus {
+    SEARCH_FOUND,
+    SEARCH_NOT_FOUND,
+    SEARCH_ERROR
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/SearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/SearchIndexService.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.search.api.service;
+
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+
+public interface SearchIndexService {
+
+    /**
+     * Search Elastic search data base using search Param.
+     *
+     * @param searchParam - Value to search elastc search database with.
+     * @return {@link ResponseObject}
+     */
+    ResponseObject search(String searchParam);
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/impl/AlphabeticalSearchIndexServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/impl/AlphabeticalSearchIndexServiceImpl.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.search.api.service.impl;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.service.SearchIndexService;
+
+@Service
+public class AlphabeticalSearchIndexServiceImpl implements SearchIndexService {
+
+    @Override
+    public ResponseObject search(String searchParam) {
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
@@ -7,13 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.Company.Items;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.SearchIndexService;
 
 import java.util.ArrayList;
@@ -23,6 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_NOT_FOUND;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -37,22 +39,23 @@ public class AlphabeticalSearchControllerTest {
     @InjectMocks
     private AlphabeticalSearchController alphabeticalSearchController;
 
+
     @Test
     @DisplayName("Test search not found")
     public void testSearchNotFound() {
 
         ResponseObject responseObject =
-            new ResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
+            new ResponseObject(SEARCH_NOT_FOUND, null);
 
         when(mockSearchIndexService.search(anyString())).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
-            .thenReturn(ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+            .thenReturn(ResponseEntity.status(NOT_FOUND).build());
 
         ResponseEntity responseEntity =
             alphabeticalSearchController.searchByCorporateName(anyString());
 
         assertNotNull(responseEntity);
-        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+        assertEquals(NOT_FOUND, responseEntity.getStatusCode());
     }
 
     @Test
@@ -60,17 +63,17 @@ public class AlphabeticalSearchControllerTest {
     public void testSearchFound() {
 
         ResponseObject responseObject =
-            new ResponseObject(ResponseStatus.SEARCH_FOUND, createSearchResults());
+            new ResponseObject(SEARCH_FOUND, createSearchResults());
 
         when(mockSearchIndexService.search(anyString())).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
-            .thenReturn(ResponseEntity.status(HttpStatus.FOUND).body(responseObject.getData()));
+            .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
         ResponseEntity responseEntity =
             alphabeticalSearchController.searchByCorporateName(anyString());
 
         assertNotNull(responseEntity);
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(FOUND, responseEntity.getStatusCode());
     }
 
     private SearchResults createSearchResults() {

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
@@ -1,0 +1,91 @@
+package uk.gov.companieshouse.search.api.controller.search;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.Company.Items;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.SearchIndexService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AlphabeticalSearchControllerTest {
+
+    @Mock
+    private SearchIndexService mockSearchIndexService;
+
+    @Mock
+    private ApiToResponseMapper mockApiToResponseMapper;
+
+    @InjectMocks
+    private AlphabeticalSearchController alphabeticalSearchController;
+
+    @Test
+    @DisplayName("Test search not found")
+    public void testSearchNotFound() {
+
+        ResponseObject responseObject =
+            new ResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
+
+        when(mockSearchIndexService.search(anyString())).thenReturn(responseObject);
+        when(mockApiToResponseMapper.map(responseObject))
+            .thenReturn(ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+
+        ResponseEntity responseEntity =
+            alphabeticalSearchController.searchByCorporateName(anyString());
+
+        assertNotNull(responseEntity);
+        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test search found")
+    public void testSearchFound() {
+
+        ResponseObject responseObject =
+            new ResponseObject(ResponseStatus.SEARCH_FOUND, createSearchResults());
+
+        when(mockSearchIndexService.search(anyString())).thenReturn(responseObject);
+        when(mockApiToResponseMapper.map(responseObject))
+            .thenReturn(ResponseEntity.status(HttpStatus.FOUND).body(responseObject.getData()));
+
+        ResponseEntity responseEntity =
+            alphabeticalSearchController.searchByCorporateName(anyString());
+
+        assertNotNull(responseEntity);
+        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+    }
+
+    private SearchResults createSearchResults() {
+        SearchResults<Items> searchResults = new SearchResults<>();
+        List<Items> companies = new ArrayList<>();
+        Items company = new Items();
+
+        company.setCompanyNumber("00004444");
+        company.setCorporateName("test name");
+        company.setCompanyStatus("test status");
+        companies.add(company);
+
+        searchResults.setSearchResults(companies);
+        searchResults.setSearchType("test search type");
+
+        return searchResults;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
@@ -6,15 +6,19 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_ERROR;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_NOT_FOUND;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -28,13 +32,13 @@ public class ApiToResponseMapperTest {
     public void testFoundReturned() {
 
         ResponseObject responseObject =
-            new ResponseObject(ResponseStatus.SEARCH_FOUND, new SearchResults());
+            new ResponseObject(SEARCH_FOUND, new SearchResults());
 
         ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
 
         assertNotNull(responseEntity);
         assertNotNull(responseEntity.getBody());
-        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+        assertEquals(FOUND, responseEntity.getStatusCode());
     }
 
     @Test
@@ -42,13 +46,13 @@ public class ApiToResponseMapperTest {
     public void testNotFoundReturned() {
 
         ResponseObject responseObject =
-            new ResponseObject(ResponseStatus.SEARCH_NOT_FOUND);
+            new ResponseObject(SEARCH_NOT_FOUND);
 
         ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
 
         assertNotNull(responseEntity);
         assertNull(responseEntity.getBody());
-        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+        assertEquals(NOT_FOUND, responseEntity.getStatusCode());
     }
 
     @Test
@@ -56,13 +60,13 @@ public class ApiToResponseMapperTest {
     public void testInternalServerErrorReturned() {
 
         ResponseObject responseObject =
-            new ResponseObject(ResponseStatus.SEARCH_ERROR);
+            new ResponseObject(SEARCH_ERROR);
 
         ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
 
         assertNotNull(responseEntity);
         assertNull(responseEntity.getBody());
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
+        assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.search.api.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ApiToResponseMapperTest {
+
+    @InjectMocks
+    private ApiToResponseMapper apiToResponseMapper;
+
+    @Test
+    @DisplayName("Test if Found returned")
+    public void testFoundReturned() {
+
+        ResponseObject responseObject =
+            new ResponseObject(ResponseStatus.SEARCH_FOUND, new SearchResults());
+
+        ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNotNull(responseEntity.getBody());
+        assertEquals(HttpStatus.FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test if Not Found returned")
+    public void testNotFoundReturned() {
+
+        ResponseObject responseObject =
+            new ResponseObject(ResponseStatus.SEARCH_NOT_FOUND);
+
+        ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNull(responseEntity.getBody());
+        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test if Internal Server Error returned")
+    public void testInternalServerErrorReturned() {
+
+        ResponseObject responseObject =
+            new ResponseObject(ResponseStatus.SEARCH_ERROR);
+
+        ResponseEntity responseEntity = apiToResponseMapper.map(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNull(responseEntity.getBody());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
+    }
+
+}


### PR DESCRIPTION
Initial creation of  Spring boot Java application for the search.api which includes
- AlphabeticalSearchController with entry point for alphabetical search and GetMethod to searchByCorporateName.
- ElasticSearchConfig file with RestHighLevelClient, which currently has hardcoded HttpHost that will in future iteration be pulled out as a chs-config and use EnvironmentReader
- ApiToResponseMapper to map response to ResponseEntity
- models for ElasticSearch data, SearchResults, ResponseObject and ResponseStatus
- Interface for SearchService
- Blank implementation of the SearchService Interface for alphabetical search

Resolves Part PCI-415