### PR TITLE
Update Makefile so that it is compatible with concourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,16 @@ build:
 
 .PHONY: package
 package:
-    @test -s ./$(artifact_name).jar || { echo "ERROR: Service JAR not found"; exit 1; }
+ifndef version
+	$(error No version given. Aborting)
+endif
+	$(info Packaging version: $(version))
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn package -DskipTests=true
 	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
 	cp ./start.sh $(tmpdir)
 	cp ./target/$(artifact_name)-$(version).jar $(tmpdir)/$(artifact_name).jar
-	cd $(tmpdir) && zip ../$(artifact_name)-$(version).zip *
+	cd $(tmpdir); zip -r ../$(artifact_name)-$(version).zip *
 	rm -rf $(tmpdir)
 
 .PHONY: dist


### PR DESCRIPTION
Concourse builds are stalling as it requires an update to the Makefile to make it compatible.

Resolves: PCI-415