### PR TITLE
Update upsert functionality to use the correct data sent from company-search-consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <java.version>1.8</java.version>
         <gson.version>2.8.5</gson.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+        <api-sdk-java.version>4.2.0</api-sdk-java.version>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.4.0</elasticsearch.version>
@@ -115,6 +116,12 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>environment-reader-library</artifactId>
             <version>${environment-reader-library.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-java</artifactId>
+            <version>${api-sdk-java.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/upsert/UpsertCompanyController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/upsert/UpsertCompanyController.java
@@ -6,8 +6,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
+
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 
@@ -24,7 +25,7 @@ public class UpsertCompanyController {
     private ApiToResponseMapper apiToResponseMapper;
 
     @PostMapping
-    public ResponseEntity upsertCompany(@Valid @RequestBody Company company) {
+    public ResponseEntity upsertCompany(@Valid @RequestBody CompanyProfileApi company) {
 
         ResponseObject responseObject = upsertCompanyService.upsert(company);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyService.java
@@ -4,10 +4,10 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
@@ -34,7 +34,7 @@ public class UpsertCompanyService {
      * @param company - Company sent over in REST call to be added/updated
      * @return {@link ResponseObject}
      */
-    public ResponseObject upsert(Company company) {
+    public ResponseObject upsert(CompanyProfileApi company) {
 
         IndexRequest indexRequest;
         UpdateRequest updateRequest;
@@ -54,7 +54,7 @@ public class UpsertCompanyService {
             return new ResponseObject(ResponseStatus.UPDATE_REQUEST_ERROR);
         }
 
-        LOG.info("Upsert successful for " + company.getId());
+        LOG.info("Upsert successful for " + company.getCompanyName());
         return new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestService.java
@@ -4,10 +4,10 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
 
 import java.io.IOException;
 
@@ -26,6 +26,7 @@ public class UpsertRequestService {
     private static final String COMPANY_STATUS = "company_status";
     private static final String CORPORATE_NAME = "corporate_name";
     private static final String RECORD_TYPE = "record_type";
+    private static final String RECORD_TYPE_VALUE = "companies";
     private static final String LINKS = "links";
     private static final String SELF = "self";
 
@@ -35,16 +36,16 @@ public class UpsertRequestService {
      * @return {@link IndexRequest}
      * @throws UpsertException
      */
-    public IndexRequest createIndexRequest(Company company) throws UpsertException {
+    public IndexRequest createIndexRequest(CompanyProfileApi company) throws UpsertException {
 
         IndexRequest indexRequest;
         try {
-            LOG.info("Preparing index request for "  + company.getId());
+            LOG.info("Preparing index request for "  + company.getCompanyName());
             indexRequest = new IndexRequest("alpha_search")
                 .source(buildRequest(company));
             return indexRequest;
         } catch (IOException e) {
-            LOG.error("Failed to index a document for company number: " + company.getId());
+            LOG.error("Failed to index a document for company number: " + company.getCompanyName());
             throw new UpsertException("Unable create index request");
         }
     }
@@ -56,36 +57,36 @@ public class UpsertRequestService {
      * @return {@link UpdateRequest}
      * @throws UpsertException
      */
-    public UpdateRequest createUpdateRequest(Company company, IndexRequest indexRequest)
+    public UpdateRequest createUpdateRequest(CompanyProfileApi company, IndexRequest indexRequest)
         throws UpsertException {
 
         UpdateRequest updateRequest;
         try {
-            LOG.info("Attempt to upsert document if it does not exist for "  + company.getId());
-            updateRequest = new UpdateRequest("alpha_search", company.getId())
+            LOG.info("Attempt to upsert document if it does not exist for "  + company.getCompanyName());
+            updateRequest = new UpdateRequest("alpha_search", company.getCompanyNumber())
                 .doc(buildRequest(company))
                 .upsert(indexRequest);
 
             return updateRequest;
         } catch (IOException e) {
-            LOG.error("Failed to update a document for company: " + company.getId());
+            LOG.error("Failed to update a document for company: " + company.getCompanyName());
             throw new UpsertException("Unable to create update request");
         }
     }
 
-    private XContentBuilder buildRequest(Company company) throws IOException {
+    private XContentBuilder buildRequest(CompanyProfileApi company) throws IOException {
         return jsonBuilder()
             .startObject()
-            .field(ID, company.getId())
-            .field(COMPANY_TYPE, company.getCompanyType())
+            .field(ID, company.getCompanyNumber())
+            .field(COMPANY_TYPE, company.getType())
             .startObject(ITEMS)
-            .field(COMPANY_NUMBER, company.getItems().getCompanyNumber())
-            .field(COMPANY_STATUS, company.getItems().getCompanyStatus())
-            .field(CORPORATE_NAME, company.getItems().getCorporateName())
-            .field(RECORD_TYPE, company.getItems().getRecordType())
+            .field(COMPANY_NUMBER, company.getCompanyNumber())
+            .field(COMPANY_STATUS, company.getCompanyStatus())
+            .field(CORPORATE_NAME, company.getCompanyName())
+            .field(RECORD_TYPE, RECORD_TYPE_VALUE)
             .endObject()
             .startObject(LINKS)
-            .field(SELF, company.getLinks().getSelf())
+            .field(SELF, company.getLinks().get(SELF))
             .endObject()
             .endObject();
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestService.java
@@ -37,13 +37,10 @@ public class UpsertRequestService {
      * @throws UpsertException
      */
     public IndexRequest createIndexRequest(CompanyProfileApi company) throws UpsertException {
-
-        IndexRequest indexRequest;
         try {
             LOG.info("Preparing index request for "  + company.getCompanyName());
-            indexRequest = new IndexRequest("alpha_search")
+            return new IndexRequest("alpha_search")
                 .source(buildRequest(company));
-            return indexRequest;
         } catch (IOException e) {
             LOG.error("Failed to index a document for company number: " + company.getCompanyName());
             throw new UpsertException("Unable create index request");
@@ -59,15 +56,12 @@ public class UpsertRequestService {
      */
     public UpdateRequest createUpdateRequest(CompanyProfileApi company, IndexRequest indexRequest)
         throws UpsertException {
-
-        UpdateRequest updateRequest;
         try {
             LOG.info("Attempt to upsert document if it does not exist for "  + company.getCompanyName());
-            updateRequest = new UpdateRequest("alpha_search", company.getCompanyNumber())
+
+            return new UpdateRequest("alpha_search", company.getCompanyNumber())
                 .doc(buildRequest(company))
                 .upsert(indexRequest);
-
-            return updateRequest;
         } catch (IOException e) {
             LOG.error("Failed to update a document for company: " + company.getCompanyName());
             throw new UpsertException("Unable to create update request");

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/upsert/UpsertCompanyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/upsert/UpsertCompanyControllerTest.java
@@ -8,12 +8,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Links;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -41,7 +42,7 @@ public class UpsertCompanyControllerTest {
     @DisplayName("Test upsert company is successful")
     void testUpsertSuccessful() {
         ResponseObject responseObject = new ResponseObject(DOCUMENT_UPSERTED);
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
 
         when(mockUpsertCompanyService.upsert(company)).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
@@ -57,7 +58,7 @@ public class UpsertCompanyControllerTest {
     @DisplayName("Test upsert company failed to index or update document")
     void testUpsertFailedToIndexOrUpdate() {
         ResponseObject responseObject = new ResponseObject(UPSERT_ERROR);
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
 
         when(mockUpsertCompanyService.upsert(company)).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
@@ -73,7 +74,7 @@ public class UpsertCompanyControllerTest {
     @DisplayName("Test upsert failed during update request")
     void testUpsertFailedUpdateRequest() {
         ResponseObject responseObject = new ResponseObject(UPDATE_REQUEST_ERROR);
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
 
         when(mockUpsertCompanyService.upsert(company)).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
@@ -85,21 +86,15 @@ public class UpsertCompanyControllerTest {
         assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
     }
 
-    private Company createCompany() {
-        Company company = new Company();
-        company.setId("ID");
-        company.setCompanyType("company type");
+    private CompanyProfileApi createCompany() {
+        CompanyProfileApi company = new CompanyProfileApi();
+        company.setType("company type");
+        company.setCompanyNumber("company number");
+        company.setCompanyStatus("company status");
+        company.setCompanyName("company name");
 
-        Items items = new Items();
-        items.setCompanyNumber("company number");
-        items.setCompanyStatus("company status");
-        items.setCorporateName("corporate name");
-        items.setRecordType("record type");
-        company.setItems(items);
-
-        Links links = new Links();
-        links.setSelf("self");
-
+        Map<String, String> links = new HashMap<>();
+        links.put("self", "company/00000000");
         company.setLinks(links);
 
         return company;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
@@ -9,14 +9,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Links;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,7 +43,7 @@ public class UpsertCompanyServiceTest {
     @DisplayName("Test upsert is successful")
     void testUpsertIsSuccessful() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
 
         when(mockUpsertRequestService.createIndexRequest(company)).thenReturn(indexRequest);
@@ -60,7 +60,7 @@ public class UpsertCompanyServiceTest {
     @DisplayName("Test exception thrown during index request")
     void testExceptionThrownDuringIndexRequest() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
 
         when(mockUpsertRequestService.createIndexRequest(company)).thenThrow(UpsertException.class);
@@ -75,7 +75,7 @@ public class UpsertCompanyServiceTest {
     @DisplayName("Test exception thrown during update request")
     void testExceptionThrownDuringUpdateRequest() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
 
         when(mockUpsertRequestService.createIndexRequest(company)).thenReturn(indexRequest);
@@ -92,9 +92,9 @@ public class UpsertCompanyServiceTest {
     @DisplayName("Test exception thrown during upsert")
     void testExceptionThrownDuringUpsert() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
-        UpdateRequest updateRequest = new UpdateRequest("alpha_search", company.getId());
+        UpdateRequest updateRequest = new UpdateRequest("alpha_search", company.getCompanyNumber());
 
         when(mockUpsertRequestService.createIndexRequest(company)).thenReturn(indexRequest);
         when(mockUpsertRequestService.createUpdateRequest(
@@ -108,21 +108,15 @@ public class UpsertCompanyServiceTest {
         assertEquals(UPDATE_REQUEST_ERROR, responseObject.getStatus());
     }
 
-    private Company createCompany() {
-        Company company = new Company();
-        company.setId("ID");
-        company.setCompanyType("company type");
+    private CompanyProfileApi createCompany() {
+        CompanyProfileApi company = new CompanyProfileApi();
+        company.setType("company type");
+        company.setCompanyNumber("company number");
+        company.setCompanyStatus("company status");
+        company.setCompanyName("company name");
 
-        Items items = new Items();
-        items.setCompanyNumber("company number");
-        items.setCompanyStatus("company status");
-        items.setCorporateName("corporate name");
-        items.setRecordType("record type");
-        company.setItems(items);
-
-        Links links = new Links();
-        links.setSelf("self");
-
+        Map<String, String> links = new HashMap<>();
+        links.put("self", "company/00000000");
         company.setLinks(links);
 
         return company;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertRequestServiceTest.java
@@ -8,10 +8,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Company;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
-import uk.gov.companieshouse.search.api.model.esdatamodel.company.Links;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,22 +32,22 @@ public class UpsertRequestServiceTest {
     @DisplayName("Test create index and update request is successful")
     void testCreateIndexRequestSuccessful() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
 
         IndexRequest indexRequest = upsertRequestService.createIndexRequest(company);
         UpdateRequest updateRequest = upsertRequestService.createUpdateRequest(company, indexRequest);
 
         assertNotNull(indexRequest);
         assertNotNull(updateRequest);
-        assertEquals(ALPHA_SEARCH, indexRequest.index().toString());
-        assertEquals(ALPHA_SEARCH, updateRequest.index().toString());
+        assertEquals(ALPHA_SEARCH, indexRequest.index());
+        assertEquals(ALPHA_SEARCH, updateRequest.index());
     }
 
     @Test
     @DisplayName("Test create index request throws exception")
     void testCreateIndexThrowsException() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
 
         when(upsertRequestService.createIndexRequest(company)).thenThrow(UpsertException.class);
 
@@ -58,7 +59,7 @@ public class UpsertRequestServiceTest {
     @DisplayName("Test create update request throws exception")
     void testUpdateIndexThrowsException() throws Exception {
 
-        Company company = createCompany();
+        CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
 
         when(upsertRequestService.createUpdateRequest(company, indexRequest))
@@ -68,21 +69,15 @@ public class UpsertRequestServiceTest {
             () -> upsertRequestService.createUpdateRequest(company, indexRequest));
     }
 
-    private Company createCompany() {
-        Company company = new Company();
-        company.setId("ID");
-        company.setCompanyType("company type");
+    private CompanyProfileApi createCompany() {
+        CompanyProfileApi company = new CompanyProfileApi();
+        company.setType("company type");
+        company.setCompanyNumber("company number");
+        company.setCompanyStatus("company status");
+        company.setCompanyName("company name");
 
-        Items items = new Items();
-        items.setCompanyNumber("company number");
-        items.setCompanyStatus("company status");
-        items.setCorporateName("corporate name");
-        items.setRecordType("record type");
-        company.setItems(items);
-
-        Links links = new Links();
-        links.setSelf("self");
-
+        Map<String, String> links = new HashMap<>();
+        links.put("self", "company/00000000");
         company.setLinks(links);
 
         return company;


### PR DESCRIPTION
Changes required to allow the consumer to send over all the data of the `stream-company-profile` topic. This future proofs the API so that if further content is added it will be easy to add additional fields.

Resolves: PCI-411