### PR TITLE
Fix for incorrectly configured Spring boot plugin and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,9 @@ all: build
 .PHONY: clean
 clean:
 	mvn clean
-	rm -f $(artifact_name)-*.zip
-	rm -f $(artifact_name).jar
+	rm -f ./$(artifact_name).jar
+	rm -f ./$(artifact_name)-*.zip
 	rm -rf ./build-*
-	rm -f ./build.log
 
 .PHONY: build
 build:
@@ -19,11 +18,28 @@ build:
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: test
-test: test-unit
+test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit: clean
 	mvn test
+
+.PHONY: test-integration
+test-integration: clean
+	mvn -Dtest=*IntegrationTest test
+
+.PHONY: test-contract-provider
+test-contract-provider: clean
+	mvn -Dtest=*ProviderContractTest test
+
+.PHONY: test-contract-consumer
+test-contract-consumer: clean
+	mvn -Dtest=*ConsumerContractTest test
+
+.PHONY: dev
+dev: clean
+	mvn package -DskipTests=true
+	cp target/$(artifact_name)-unversioned.jar $(artifact_name).jar
 
 .PHONY: package
 package:
@@ -49,4 +65,4 @@ sonar:
 
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
-	mvn sonar:sonar -P sonar-pr-analysis
+	mvn sonar:sonar	-P sonar-pr-analysis

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <gson.version>2.8.5</gson.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <api-sdk-java.version>4.2.0</api-sdk-java.version>
+        <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.4.0</elasticsearch.version>
@@ -145,7 +146,17 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot-maven-plugin.version}</version>
+                <configuration>
+                    <mainClass>${start-class}</mainClass>
+                    <layout>ZIP</layout>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This correctly configures `pom.xml` to include `mainClass` property in `spring-boot-maven-plugin` and updates Makefile to include `make dev` command.