### PR TITLE
Explicilty define elasticsearch-rest-client in pom to prevent it defaulting to old version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
         <relativePath />
     </parent>
 
@@ -108,6 +108,12 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
             <version>${elasticsearch.version}</version>
         </dependency>
 


### PR DESCRIPTION
Without the `elasticsearch-rest-client` explicitly defined it defaults to version `6.4.0` which causes issues in docker due to the methods not being present in that version.