### PR TITLE
Create base get dissolved method to enable dissolved search development

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,4 +3,5 @@ group: api
 weight: 902
 routes:
   1: ^/alphabetical-search/companies
-  2: ^/upsert-company
+  2: ^/dissolved-search/companies
+  3: ^/upsert-company

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
+import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 
 @RestController
 @RequestMapping(value = "/alphabetical-search", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -21,7 +21,7 @@ public class AlphabeticalSearchController {
     private static final String COMPANY_NAME_QUERY_PARAM = "q";
 
     @Autowired
-    private SearchIndexService searchIndexService;
+    private AlphabeticalSearchIndexService searchIndexService;
 
     @Autowired
     private ApiToResponseMapper apiToResponseMapper;

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -28,7 +28,7 @@ public class DissolvedSearchController {
 
     @GetMapping("/companies")
     @ResponseBody
-    public ResponseEntity searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
+    public ResponseEntity<Object> searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
                                                 @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
 
         DissolvedResponseObject responseObject = searchIndexService

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -1,4 +1,39 @@
 package uk.gov.companieshouse.search.api.controller.search;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
+import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
+
+@RestController
+@RequestMapping(value = "/dissolved-search", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DissolvedSearchController {
+
+    @Autowired
+    private DissolvedSearchIndexService searchIndexService;
+
+    @Autowired
+    private ApiToResponseMapper apiToResponseMapper;
+
+    private static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
+    private static final String COMPANY_NAME_QUERY_PARAM = "q";
+
+    @GetMapping("/companies")
+    @ResponseBody
+    public ResponseEntity searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
+                                                @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
+
+        DissolvedResponseObject responseObject = searchIndexService
+                .search(companyName, requestId);
+
+        return apiToResponseMapper.mapDissolved(responseObject);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.search.api.controller.search;
+
+public class DissolvedSearchController {
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.search.api.mapper;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -24,6 +25,19 @@ public class ApiToResponseMapper {
             case UPDATE_REQUEST_ERROR:
             case UPSERT_ERROR:
                 return ResponseEntity.status(BAD_REQUEST).build();
+            default:
+                return ResponseEntity.status(INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    // To be removed when alphabetical search response has been updated
+    public ResponseEntity mapDissolved(DissolvedResponseObject responseObject) {
+
+        switch(responseObject.getStatus()) {
+            case SEARCH_FOUND:
+                return ResponseEntity.status(OK).body(responseObject.getData());
+            case SEARCH_NOT_FOUND:
+                return ResponseEntity.status(NOT_FOUND).build();
             default:
                 return ResponseEntity.status(INTERNAL_SERVER_ERROR).build();
         }

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -6,7 +6,6 @@ import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
@@ -14,7 +13,7 @@ import static org.springframework.http.HttpStatus.OK;
 @Component
 public class ApiToResponseMapper {
 
-    public ResponseEntity map(ResponseObject responseObject) {
+    public ResponseEntity<Object> map(ResponseObject responseObject) {
 
         switch(responseObject.getStatus()) {
             case SEARCH_FOUND:
@@ -31,7 +30,7 @@ public class ApiToResponseMapper {
     }
 
     // To be removed when alphabetical search response has been updated
-    public ResponseEntity mapDissolved(DissolvedResponseObject responseObject) {
+    public ResponseEntity<Object> mapDissolved(DissolvedResponseObject responseObject) {
 
         switch(responseObject.getStatus()) {
             case SEARCH_FOUND:

--- a/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.search.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class DissolvedSearchResults<T> {
+
+    @JsonProperty("etag")
+    private String etag;
+
+    @JsonProperty("top_hit")
+    private TopHit topHit;
+
+    @JsonProperty("items")
+    private List<T> items;
+
+    public DissolvedSearchResults() {
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+
+    public TopHit getTopHit() {
+        return topHit;
+    }
+
+    public void setTopHit(TopHit topHit) {
+        this.topHit = topHit;
+    }
+
+    public List<T> getItems() {
+        return items;
+    }
+
+    public void setItems(List<T> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
@@ -18,6 +18,12 @@ public class DissolvedSearchResults<T> {
     public DissolvedSearchResults() {
     }
 
+    public DissolvedSearchResults(String etag, TopHit topHit, List<T> items) {
+        this.etag = etag;
+        this.topHit = topHit;
+        this.items = items;
+    }
+
     public String getEtag() {
         return etag;
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/model/TopHit.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/TopHit.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.search.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TopHit {
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("company_number")
+    private String companyNumber;
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/Address.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/Address.java
@@ -1,7 +1,11 @@
 package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
 
     @JsonProperty("locality")

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/Address.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/Address.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Address {
+
+    @JsonProperty("locality")
+    private String locality;
+
+    @JsonProperty("postal_code")
+    private String postalCode;
+
+    public String getLocality() {
+        return locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/DissolvedCompany.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/DissolvedCompany.java
@@ -1,0 +1,85 @@
+package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class DissolvedCompany {
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("company_number")
+    private String companyNumber;
+
+    @JsonProperty("company_status")
+    private String companyStatus;
+
+    @JsonProperty("date_of_cessation")
+    private String dateOfCessation;
+
+    @JsonProperty("date_of_creation")
+    private String dateOfCreation;
+
+    @JsonProperty("address")
+    private Address address;
+
+    @JsonProperty("previous_company_names")
+    private List<PreviousCompanyName> previousCompanyNames;
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public String getCompanyStatus() {
+        return companyStatus;
+    }
+
+    public void setCompanyStatus(String companyStatus) {
+        this.companyStatus = companyStatus;
+    }
+
+    public String getDateOfCessation() {
+        return dateOfCessation;
+    }
+
+    public void setDateOfCessation(String dateOfCessation) {
+        this.dateOfCessation = dateOfCessation;
+    }
+
+    public String getDateOfCreation() {
+        return dateOfCreation;
+    }
+
+    public void setDateOfCreation(String dateOfCreation) {
+        this.dateOfCreation = dateOfCreation;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public List<PreviousCompanyName> getPreviousCompanyNames() {
+        return previousCompanyNames;
+    }
+
+    public void setPreviousCompanyNames(List<PreviousCompanyName> previousCompanyNames) {
+        this.previousCompanyNames = previousCompanyNames;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/DissolvedCompany.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/DissolvedCompany.java
@@ -1,9 +1,13 @@
 package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DissolvedCompany {
 
     @JsonProperty("company_name")

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/PreviousCompanyName.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/PreviousCompanyName.java
@@ -1,7 +1,11 @@
 package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PreviousCompanyName {
 
     @JsonProperty("date_of_name_cessation")

--- a/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/PreviousCompanyName.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/esdatamodel/dissolved/PreviousCompanyName.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.search.api.model.esdatamodel.dissolved;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PreviousCompanyName {
+
+    @JsonProperty("date_of_name_cessation")
+    private String dateOfNameCessation;
+
+    @JsonProperty("date_of_name_effectiveness")
+    private String dateOfNameEffectiveness;
+
+    @JsonProperty("name")
+    private String name;
+
+    public String getDateOfNameCessation() {
+        return dateOfNameCessation;
+    }
+
+    public void setDateOfNameCessation(String dateOfNameCessation) {
+        this.dateOfNameCessation = dateOfNameCessation;
+    }
+
+    public String getDateOfNameEffectiveness() {
+        return dateOfNameEffectiveness;
+    }
+
+    public void setDateOfNameEffectiveness(String dateOfNameEffectiveness) {
+        this.dateOfNameEffectiveness = dateOfNameEffectiveness;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/response/DissolvedResponseObject.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/response/DissolvedResponseObject.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.search.api.model.response;
+
+import com.google.gson.Gson;
+import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
+
+public class DissolvedResponseObject {
+
+    private ResponseStatus status;
+
+    private DissolvedSearchResults dissolvedSearchResults;
+
+    public DissolvedResponseObject(ResponseStatus status) {
+        this.status = status;
+    }
+
+    public DissolvedResponseObject(ResponseStatus status, DissolvedSearchResults dissolvedSearchResults) {
+        this.status = status;
+        this.dissolvedSearchResults = dissolvedSearchResults;
+    }
+
+    public ResponseStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ResponseStatus status) {
+        this.status = status;
+    }
+
+    public DissolvedSearchResults getData() {
+        return dissolvedSearchResults;
+    }
+
+    public void setData(DissolvedSearchResults dissolvedSearchResults) {
+        this.dissolvedSearchResults = dissolvedSearchResults;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -5,8 +5,14 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
 import uk.gov.companieshouse.search.api.model.TopHit;
+import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.Address;
+import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.DissolvedCompany;
+import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.PreviousCompanyName;
 import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static uk.gov.companieshouse.search.api.SearchApiApplication.APPLICATION_NAME_SPACE;
 
@@ -19,13 +25,38 @@ public class DissolvedSearchIndexService {
 
     public DissolvedResponseObject search(String companyName, String requestId) {
 
-        DissolvedSearchResults searchResults = new DissolvedSearchResults();
-        searchResults.setEtag("TEST");
         TopHit topHit = new TopHit();
         topHit.setCompanyName("TEST COMPANY NAME");
         topHit.setCompanyNumber("TEST COMPANY NUMBER");
+
+        List<DissolvedCompany> dissolvedCompanies = new ArrayList<>();
+        DissolvedCompany dissolvedCompany = new DissolvedCompany();
+        Address address = new Address();
+        address.setLocality("TEST LOCALITY");
+        address.setPostalCode("AB12 3CD");
+
+        PreviousCompanyName previousCompanyName = new PreviousCompanyName();
+        previousCompanyName.setDateOfNameCessation("01/01/1993");
+        previousCompanyName.setDateOfNameEffectiveness("01/01/1983");
+        previousCompanyName.setName("PREVIOUS NAME");
+
+        List<PreviousCompanyName> previousCompanyNames = new ArrayList<>();
+        previousCompanyNames.add(previousCompanyName);
+
+        dissolvedCompany.setCompanyName("TEST COMPANY NAME");
+        dissolvedCompany.setCompanyNumber("TEST COMPANY NUMBER");
+        dissolvedCompany.setCompanyStatus("TEST COMPANY STATUS");
+        dissolvedCompany.setDateOfCessation("TEST DATE OF CESSATION");
+        dissolvedCompany.setDateOfCreation("TEST DATE OF CREATION");
+        dissolvedCompany.setAddress(address);
+        dissolvedCompany.setPreviousCompanyNames(previousCompanyNames);
+
+        dissolvedCompanies.add(dissolvedCompany);
+
+        DissolvedSearchResults searchResults = new DissolvedSearchResults();
         searchResults.setTopHit(topHit);
-        searchResults.setItems(null);
+        searchResults.setEtag("TEST");
+        searchResults.setItems(dissolvedCompanies);
 
         LOG.info(DISSOLVED_SEARCH + "successful for: " + companyName);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.search.api.service.search.impl.dissolved;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
+import uk.gov.companieshouse.search.api.model.TopHit;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+
+import static uk.gov.companieshouse.search.api.SearchApiApplication.APPLICATION_NAME_SPACE;
+
+@Service
+public class DissolvedSearchIndexService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    private static final String DISSOLVED_SEARCH = "Dissolved search: ";
+
+    public DissolvedResponseObject search(String companyName, String requestId) {
+
+        DissolvedSearchResults searchResults = new DissolvedSearchResults();
+        searchResults.setEtag("TEST");
+        TopHit topHit = new TopHit();
+        topHit.setCompanyName("TEST COMPANY NAME");
+        topHit.setCompanyNumber("TEST COMPANY NUMBER");
+        searchResults.setTopHit(topHit);
+        searchResults.setItems(null);
+
+        LOG.info(DISSOLVED_SEARCH + "successful for: " + companyName);
+        return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/AlphabeticalSearchControllerTest.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
+import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,7 @@ import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEA
 public class AlphabeticalSearchControllerTest {
 
     @Mock
-    private SearchIndexService mockSearchIndexService;
+    private AlphabeticalSearchIndexService mockSearchIndexService;
 
     @Mock
     private ApiToResponseMapper mockApiToResponseMapper;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.search.api.controller.search;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
+import uk.gov.companieshouse.search.api.model.TopHit;
+import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
+import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.DissolvedCompany;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
+import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DissolvedSearchControllerTest {
+
+    @Mock
+    private DissolvedSearchIndexService mockSearchIndexService;
+
+    @Mock
+    private ApiToResponseMapper mockApiToResponseMapper;
+
+    @InjectMocks
+    private DissolvedSearchController dissolvedSearchController;
+
+    private static final String REQUEST_ID = "requestID";
+    private static final String COMPANY_NAME = "test company";
+    private static final String COMPANY_NUMBER = "00000000";
+
+    @Test
+    @DisplayName("Test search found")
+    void testSearchFound() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
+
+        when(mockSearchIndexService.search(COMPANY_NAME, REQUEST_ID)).thenReturn(responseObject);
+        when(mockApiToResponseMapper.mapDissolved(responseObject))
+                .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
+
+        ResponseEntity responseEntity =
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(responseEntity);
+        assertEquals(FOUND, responseEntity.getStatusCode());
+    }
+
+    private DissolvedSearchResults createSearchResults() {
+        DissolvedSearchResults<DissolvedCompany> searchResults = new DissolvedSearchResults<>();
+        List<DissolvedCompany> companies = new ArrayList<>();
+        DissolvedCompany company = new DissolvedCompany();
+
+        company.setCompanyNumber(COMPANY_NUMBER);
+        company.setCompanyName(COMPANY_NAME);
+        company.setCompanyStatus(COMPANY_NUMBER);
+        companies.add(company);
+
+        TopHit topHit = new TopHit();
+        topHit.setCompanyNumber("00004444");
+        topHit.setCompanyName(COMPANY_NAME);
+
+        searchResults.setItems(companies);
+        searchResults.setEtag("test etag");
+        searchResults.setTopHit(topHit);
+
+
+        return searchResults;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -27,7 +27,7 @@ import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEA
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class DissolvedSearchControllerTest {
+class DissolvedSearchControllerTest {
 
     @Mock
     private DissolvedSearchIndexService mockSearchIndexService;

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
@@ -134,7 +134,7 @@ class ApiToResponseMapperTest {
 
     @Test
     @DisplayName("Test if Not Found returned for dissolved company")
-    public void testNotFoundReturnedDissolved() {
+    void testNotFoundReturnedDissolved() {
 
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_NOT_FOUND);
@@ -148,7 +148,7 @@ class ApiToResponseMapperTest {
 
     @Test
     @DisplayName("Test if Internal Server Error returned for dissolved company")
-    public void testInternalServerErrorReturnedDissolved() {
+    void testInternalServerErrorReturnedDissolved() {
 
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_ERROR);

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
@@ -7,14 +7,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
 import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
@@ -117,4 +118,45 @@ public class ApiToResponseMapperTest {
         assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
     }
 
+    @Test
+    @DisplayName("Test if Search found returned for dissolved company")
+    public void testFoundReturnedDissolved() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_FOUND, new DissolvedSearchResults());
+
+        ResponseEntity responseEntity = apiToResponseMapper.mapDissolved(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNotNull(responseEntity.getBody());
+        assertEquals(OK, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test if Not Found returned for dissolved company")
+    public void testNotFoundReturnedDissolved() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_NOT_FOUND);
+
+        ResponseEntity responseEntity = apiToResponseMapper.mapDissolved(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNull(responseEntity.getBody());
+        assertEquals(NOT_FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test if Internal Server Error returned for dissolved company")
+    public void testInternalServerErrorReturnedDissolved() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_ERROR);
+
+        ResponseEntity responseEntity = apiToResponseMapper.mapDissolved(responseObject);
+
+        assertNotNull(responseEntity);
+        assertNull(responseEntity.getBody());
+        assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.search.api.service.search;
+package uk.gov.companieshouse.search.api.service.search.alphabetical;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +14,8 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.company.Items;
 import uk.gov.companieshouse.search.api.model.esdatamodel.company.Links;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
+import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.search.api.service.search;
+package uk.gov.companieshouse.search.api.service.search.alphabetical;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
+import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchRequestService;
 
 import java.io.IOException;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.search.api.service.search.dissolved;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DissolvedSearchIndexServiceTest {
+
+    @InjectMocks
+    DissolvedSearchIndexService searchIndexService;
+
+    private static final String REQUEST_ID = "requestId";
+    private static final String COMPANY_NAME = "test company";
+
+    @Test
+    @DisplayName("Test search request returns successfully")
+    void searchRequestSuccessful() throws Exception {
+
+        DissolvedResponseObject responseObject = searchIndexService.search(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(responseObject.getStatus(), ResponseStatus.SEARCH_FOUND);
+    }
+}


### PR DESCRIPTION
- Add controller for dissolved search
- Add basic dissolved search index service that returns test dummy data
- The `ResponseObject`, `SearchResults` and `ApiResponseMapper` are strongly coupled with the alphabetical search results, therefore I have created a separate version for dissolved search. The alphabetical search way will eventually be removed in favour of the dissolved when working on making the API publicly consumable.
- Increase unit test coverage

Resolves: BI-6804