### PR TITLE
BI-6773, GCI-1136 - Return a result when user adds random search terms

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchQuery.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchQuery.java
@@ -10,6 +10,8 @@ public abstract class AbstractSearchQuery {
     abstract QueryBuilder createOrderedAlphaKeyKeywordQuery(String orderedAlphaKey);
     
     abstract QueryBuilder createStartsWithQuery(String corporateName);
+
+    abstract QueryBuilder createNoResultsFoundQuery(String orderedAlphaKey);
     
     public QueryBuilder createMatchAllQuery() {
 

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
@@ -106,8 +106,6 @@ public abstract class AbstractSearchRequest {
                 getSearchQuery().createNoResultsFoundQuery(orderedAlphakey),
                 ORDERED_ALPHA_KEY_WITH_ID, SortOrder.ASC));
 
-        System.out.println(searchRequestNoResults);
-
         SearchResponse searchResponse = getRestClientService().search(searchRequestNoResults);
         return searchResponse.getHits();
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
@@ -99,6 +99,19 @@ public abstract class AbstractSearchRequest {
         return searchResponse.getHits();
     }
 
+    public SearchHits noResultsFallbackQuery(String orderedAlphakey, String requestId) throws IOException {
+        LOG.info("Failed to return any results for: " + orderedAlphakey + ". Breaking search term down to find results");
+        SearchRequest searchRequestNoResults = createBaseSearchRequest(requestId);
+        searchRequestNoResults.source(bestMatchSourceBuilder(
+                getSearchQuery().createNoResultsFoundQuery(orderedAlphakey),
+                ORDERED_ALPHA_KEY_WITH_ID, SortOrder.ASC));
+
+        System.out.println(searchRequestNoResults);
+
+        SearchResponse searchResponse = getRestClientService().search(searchRequestNoResults);
+        return searchResponse.getHits();
+    }
+
     private SearchRequest createBaseSearchRequest(String requestId) {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indices(environmentReader.getMandatoryString(getIndex()));

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueries.java
@@ -4,6 +4,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @Component
 public class AlphabeticalSearchQueries extends AbstractSearchQuery {
 
@@ -21,5 +25,22 @@ public class AlphabeticalSearchQueries extends AbstractSearchQuery {
     public QueryBuilder createStartsWithQuery(String corporateName) {
 
         return QueryBuilders.matchPhrasePrefixQuery("items.corporate_name.startswith", corporateName);
+    }
+
+    public QueryBuilder createNoResultsFoundQuery(String orderedAlphaKey) {
+
+        List<String> tokens = new ArrayList<>();
+
+        for (int i=0; i < orderedAlphaKey.length(); i++) {
+
+            if (i != orderedAlphaKey.length() - 1) {
+                String resultString = orderedAlphaKey.substring(0, orderedAlphaKey.length() - i);
+                tokens.add(resultString);
+            }
+        }
+
+        Collections.reverse(tokens);
+
+        return QueryBuilders.termsQuery("items.ordered_alpha_key.keyword", tokens);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueries.java
@@ -3,9 +3,8 @@ package uk.gov.companieshouse.search.api.elasticsearch;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.search.api.util.StringTokeniserUtil;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Component
@@ -29,17 +28,7 @@ public class AlphabeticalSearchQueries extends AbstractSearchQuery {
 
     public QueryBuilder createNoResultsFoundQuery(String orderedAlphaKey) {
 
-        List<String> tokens = new ArrayList<>();
-
-        for (int i=0; i < orderedAlphaKey.length(); i++) {
-
-            if (i != orderedAlphaKey.length() - 1) {
-                String resultString = orderedAlphaKey.substring(0, orderedAlphaKey.length() - i);
-                tokens.add(resultString);
-            }
-        }
-
-        Collections.reverse(tokens);
+        List<String> tokens = StringTokeniserUtil.tokeniseString(orderedAlphaKey);
 
         return QueryBuilders.termsQuery("items.ordered_alpha_key.keyword", tokens);
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -3,9 +3,8 @@ package uk.gov.companieshouse.search.api.elasticsearch;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.search.api.util.StringTokeniserUtil;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Component
@@ -25,17 +24,7 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
 
     public QueryBuilder createNoResultsFoundQuery(String orderedAlphaKey) {
 
-        List<String> tokens = new ArrayList<>();
-
-        for (int i=0; i < orderedAlphaKey.length(); i++) {
-
-            if (i != orderedAlphaKey.length() - 1) {
-                String resultString = orderedAlphaKey.substring(0, orderedAlphaKey.length() - i);
-                tokens.add(resultString);
-            }
-        }
-
-        Collections.reverse(tokens);
+        List<String> tokens = StringTokeniserUtil.tokeniseString(orderedAlphaKey);
 
         return QueryBuilders.termsQuery("ordered_alpha_key", tokens);
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -4,6 +4,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @Component
 public class DissolvedSearchQueries extends AbstractSearchQuery {
 
@@ -17,5 +21,22 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
 
     public QueryBuilder createStartsWithQuery(String corporateName) {
         return QueryBuilders.matchPhrasePrefixQuery("company_name.startswith", corporateName);
+    }
+
+    public QueryBuilder createNoResultsFoundQuery(String orderedAlphaKey) {
+
+        List<String> tokens = new ArrayList<>();
+
+        for (int i=0; i < orderedAlphaKey.length(); i++) {
+
+            if (i != orderedAlphaKey.length() - 1) {
+                String resultString = orderedAlphaKey.substring(0, orderedAlphaKey.length() - i);
+                tokens.add(resultString);
+            }
+        }
+
+        Collections.reverse(tokens);
+
+        return QueryBuilders.termsQuery("ordered_alpha_key", tokens);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -69,6 +69,12 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
                     .getCorporateNameStartsWithResponse(orderedAlphakey, requestId);
             }
 
+            if (hits.getTotalHits().value == 0) {
+
+                hits = alphabeticalSearchRequests
+                        .noResultsFallbackQuery(orderedAlphakey, requestId);
+            }
+
             if (hits.getTotalHits().value > 0) {
                 LOG.info("A result has been found");
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -61,6 +61,12 @@ public class DissolvedSearchRequestService {
                 hits = dissolvedSearchRequests.getCorporateNameStartsWithResponse(orderedAlphaKey, requestId);
             }
 
+            if (hits.getTotalHits().value == 0) {
+
+                hits = dissolvedSearchRequests
+                        .noResultsFallbackQuery(orderedAlphaKey, requestId);
+            }
+
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info("A result has been found", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
 import uk.gov.companieshouse.search.api.model.DissolvedTopHit;
-import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.Address;
 import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.DissolvedCompany;
 import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.PreviousCompanyName;

--- a/src/main/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtil.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtil.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 public class StringTokeniserUtil {
 
+    private StringTokeniserUtil() {
+        throw new IllegalStateException("Utility class - Not to be instantiated");
+    }
+
     public static List<String> tokeniseString(String str) {
         List<String> tokens = new ArrayList<>();
 

--- a/src/main/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtil.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtil.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.search.api.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class StringTokeniserUtil {
+
+    public static List<String> tokeniseString(String str) {
+        List<String> tokens = new ArrayList<>();
+
+        for (int i = 0; i < str.length(); i++) {
+
+            if (i != str.length() - 1) {
+                String resultString = str.substring(0, str.length() - i);
+                tokens.add(resultString);
+            }
+        }
+        Collections.reverse(tokens);
+
+        return tokens;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueriesTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueriesTest.java
@@ -4,7 +4,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class AlphabeticalSearchQueriesTest {

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueriesTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchQueriesTest.java
@@ -4,6 +4,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class AlphabeticalSearchQueriesTest {
@@ -33,6 +34,15 @@ class AlphabeticalSearchQueriesTest {
     void createStartsWithQuery() {
         QueryBuilder queryBuilder =
             alphabeticalSearchQueries.createStartsWithQuery("corporateNameStartsWith");
+
+        assertNotNull(queryBuilder);
+    }
+
+    @Test
+    @DisplayName("Create No Results Found Fallback Query")
+    void createNoResultsFoundFallbackQuery() {
+        QueryBuilder queryBuilder =
+                alphabeticalSearchQueries.createNoResultsFoundQuery("orderAlphakey");
 
         assertNotNull(queryBuilder);
     }

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
@@ -115,6 +115,20 @@ class AlphabeticalSearchRequestsTest {
         assertEquals(1, searchHits.getTotalHits().value);
     }
 
+    @Test
+    @DisplayName("Get no results found fallback response")
+    void noResultsFallbackQueryResponse() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
+        when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+
+        SearchHits searchHits = alphabeticalSearchRequests
+                .noResultsFallbackQuery("orderedAlpha", "requestId");
+
+        assertNotNull(searchHits);
+        assertEquals(1, searchHits.getTotalHits().value);
+    }
+
     private SearchResponse createSearchResponse() {
         BytesReference source = new BytesArray(
             "{test}" );

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueriesTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueriesTest.java
@@ -38,6 +38,15 @@ class DissolvedSearchQueriesTest {
     }
 
     @Test
+    @DisplayName("Create No Results Found Fallback Query")
+    void createNoResultsFoundFallbackQuery() {
+        QueryBuilder queryBuilder =
+                dissolvedSearchQueries.createNoResultsFoundQuery("orderAlphakey");
+
+        assertNotNull(queryBuilder);
+    }
+
+    @Test
     @DisplayName("Create Alphabetical Query")
     void createAlphabeticalQuery() {
         QueryBuilder queryBuilder =

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -118,6 +118,20 @@ class DissolvedSearchRequestsTest {
         assertEquals(1, searchHits.getTotalHits().value);
     }
 
+    @Test
+    @DisplayName("Get no results found fallback response")
+    void noResultsFallbackQueryResponse() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
+        when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+
+        SearchHits searchHits = dissolvedSearchRequests
+                .noResultsFallbackQuery("orderedAlpha", "requestId");
+
+        assertNotNull(searchHits);
+        assertEquals(1, searchHits.getTotalHits().value);
+    }
+
     private SearchResponse createSearchResponse() {
         BytesReference source = new BytesArray(
                 "{test}" );

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -18,7 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.rest.impl.DissolvedSearchRestClientService;
 
 import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
+import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
@@ -129,6 +130,41 @@ class AlphabeticalSearchRequestServiceTest {
 
         SearchResults searchResults =
             searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, REQUEST_ID);
+
+        assertNotNull(searchResults);
+        assertEquals(TOP_HIT, searchResults.getTopHit());
+        assertEquals(3, searchResults.getResults().size());
+    }
+
+    @Test
+    @DisplayName("Test search request returns results successfully with no results found fallback query")
+    void testNoResultsFoundFallbackSuccessful() throws Exception{
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(CORPORATE_NAME))
+                .thenReturn(createAlphaKeyResponse());
+
+        when(mockAlphabeticalSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.noResultsFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createSearchHits());
+
+        when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits());
+
+        when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits());
+
+        SearchResults searchResults =
+                searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, REQUEST_ID);
 
         assertNotNull(searchResults);
         assertEquals(TOP_HIT, searchResults.getTopHit());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
-import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -14,7 +14,6 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.Address;
 import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.DissolvedCompany;
 import uk.gov.companieshouse.search.api.model.esdatamodel.dissolved.PreviousCompanyName;
 import uk.gov.companieshouse.search.api.model.response.DissolvedResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchRequestService;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -138,6 +138,41 @@ class DissolvedSearchRequestServiceTest {
         assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
         assertEquals(3, dissolvedSearchResults.getItems().size());
     }
+
+    @Test
+    @DisplayName("Test search request returns results successfully with no results found fallback query")
+    void testNoResultsFoundFallbackSuccessful() throws Exception{
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME))
+                .thenReturn(createAlphaKeyResponse());
+
+        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.noResultsFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createSearchHits(true, true, true));
+
+        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits(true, true, true));
+
+        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits(true, true, true));
+
+        DissolvedSearchResults dissolvedSearchResults =
+                dissolvedSearchRequestService.getSearchResults(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(dissolvedSearchResults);
+        assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
+        assertEquals(3, dissolvedSearchResults.getItems().size());
+    }
     
     @Test
     @DisplayName("Test search request returns results successfully with corporate name starts with query when locality missing")

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -13,15 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.elasticsearch.DissolvedSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.model.DissolvedSearchResults;
-import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
-import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
-import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchRequestService;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchRequestService;
 
 import java.io.IOException;

--- a/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.search.api.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringTokeniserUtilTest {
+
+    @Test
+    @DisplayName("Test tokenising of string successful")
+    void tokeniseString() {
+        String testString = "ABCDEFGH";
+        List<String> tokens = StringTokeniserUtil.tokeniseString(testString);
+
+        assertEquals(true, tokens.contains("AB"));
+        assertEquals(true, tokens.contains("ABC"));
+        assertEquals(true, tokens.contains("ABCD"));
+        assertEquals(true, tokens.contains("ABCDE"));
+        assertEquals(true, tokens.contains("ABCDEF"));
+        assertEquals(true, tokens.contains("ABCDEFG"));
+        assertEquals(true, tokens.contains("ABCDEFGH"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
@@ -1,11 +1,17 @@
 package uk.gov.companieshouse.search.api.util;
 
+import com.sun.tools.corba.se.idl.toJavaPortable.Helper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringTokeniserUtilTest {
 
@@ -22,5 +28,15 @@ class StringTokeniserUtilTest {
         assertEquals(true, tokens.contains("ABCDEF"));
         assertEquals(true, tokens.contains("ABCDEFG"));
         assertEquals(true, tokens.contains("ABCDEFGH"));
+    }
+
+    @Test
+    @DisplayName("Test instantiating private constructor throws exception")
+    public void privateConstructorTest() throws Exception {
+        Constructor<StringTokeniserUtil> constructor = StringTokeniserUtil.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+
+        assertThrows(InvocationTargetException.class, constructor::newInstance);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
@@ -32,7 +32,7 @@ class StringTokeniserUtilTest {
 
     @Test
     @DisplayName("Test instantiating private constructor throws exception")
-    public void privateConstructorTest() throws Exception {
+    void privateConstructorTest() throws Exception {
         Constructor<StringTokeniserUtil> constructor = StringTokeniserUtil.class.getDeclaredConstructor();
         assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);

--- a/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/util/StringTokeniserUtilTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.search.api.util;
 
-import com.sun.tools.corba.se.idl.toJavaPortable.Helper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Adds terms query for alphabetical and dissolved search to break down the users search term into tokens which are each in turn check for an exact match in the index. An example of this would be:

- User searches `fdsfsf`
- Doesn’t find an exact company called `fdsfsf`  - tries `fdsfs`
- Doesn’t find an exact company called `fdsf`  - tries `fds`
- Doesn’t find an exact company called `fds`  - tries `fd`
- Match found for `fd` - returns the company result for `fd`

Resolves: BI-6773, GCI-1136