### PR TITLE
Additional fallback - Break search term down to first two characters and search for best match

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
@@ -127,6 +127,15 @@ public abstract class AbstractSearchRequest {
         return searchResponse.getHits();
     }
 
+    public SearchHits finalFallbackQuery(String orderedAlphakey, String requestId) throws IOException {
+        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
+        logMap.put(LoggingUtils.ORDERED_ALPHAKEY, orderedAlphakey);
+        LoggingUtils.getLogger()
+                .info("Final fallback - breaking down search term to bare minimum: " + orderedAlphakey.substring(0,2), logMap);
+
+        return getStartsWithResponse(orderedAlphakey.substring(0,2), requestId);
+    }
+
     private SearchRequest createBaseSearchRequest(String requestId) {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indices(environmentReader.getMandatoryString(getIndex()));

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -75,6 +75,11 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
                         .noResultsFallbackQuery(orderedAlphakey, requestId);
             }
 
+            if (hits.getTotalHits().value == 0) {
+
+                hits = alphabeticalSearchRequests.finalFallbackQuery(orderedAlphakey, requestId);
+            }
+
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info("A result has been found", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -32,7 +32,6 @@ public class DissolvedSearchRequestService {
     @Autowired
     private DissolvedSearchRequests dissolvedSearchRequests;
 
-    private static final String DISSOLVED_SEARCH = "Dissolved Search: ";
     private static final String SEARCH_RESULTS_KIND = "searchresults#dissolvedCompany";
 
     public DissolvedSearchResults getSearchResults(String companyName, String requestId) throws SearchException {
@@ -67,6 +66,11 @@ public class DissolvedSearchRequestService {
 
                 hits = dissolvedSearchRequests
                         .noResultsFallbackQuery(orderedAlphaKey, requestId);
+            }
+
+            if (hits.getTotalHits().value == 0) {
+
+                hits = dissolvedSearchRequests.finalFallbackQuery(orderedAlphaKey, requestId);
             }
 
             if (hits.getTotalHits().value > 0) {

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
@@ -129,6 +129,20 @@ class AlphabeticalSearchRequestsTest {
         assertEquals(1, searchHits.getTotalHits().value);
     }
 
+    @Test
+    @DisplayName("Get final fallback response")
+    void finalFallbackResponse() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
+        when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+
+        SearchHits searchHits = alphabeticalSearchRequests
+                .finalFallbackQuery("orderedAlpha", "requestId");
+
+        assertNotNull(searchHits);
+        assertEquals(1, searchHits.getTotalHits().value);
+    }
+
     private SearchResponse createSearchResponse() {
         BytesReference source = new BytesArray(
             "{test}" );

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -131,6 +131,20 @@ class DissolvedSearchRequestsTest {
         assertEquals(1, searchHits.getTotalHits().value);
     }
 
+    @Test
+    @DisplayName("Get final fallback response")
+    void finalFallbackResponse() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
+        when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+
+        SearchHits searchHits = dissolvedSearchRequests
+                .finalFallbackQuery("orderedAlpha", "requestId");
+
+        assertNotNull(searchHits);
+        assertEquals(1, searchHits.getTotalHits().value);
+    }
+
     private SearchResponse createSearchResponse() {
         BytesReference source = new BytesArray(
                 "{test}" );

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -171,6 +171,44 @@ class AlphabeticalSearchRequestServiceTest {
     }
 
     @Test
+    @DisplayName("Test final fallback query returns a result")
+    void testFinalFallbackQuery() throws Exception{
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(CORPORATE_NAME))
+                .thenReturn(createAlphaKeyResponse());
+
+        when(mockAlphabeticalSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.noResultsFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockAlphabeticalSearchRequests.finalFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createSearchHits());
+
+        when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits());
+
+        when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits());
+
+        SearchResults searchResults =
+                searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, REQUEST_ID);
+
+        assertNotNull(searchResults);
+        assertEquals(TOP_HIT, searchResults.getTopHit());
+        assertEquals(3, searchResults.getResults().size());
+    }
+
+    @Test
     @DisplayName("Test search request throws exception")
     void testThrowException() throws Exception{
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -172,6 +172,44 @@ class DissolvedSearchRequestServiceTest {
     }
 
     @Test
+    @DisplayName("Test final fallback query returns a result")
+    void testFinalFallbackQuery() throws Exception{
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME))
+                .thenReturn(createAlphaKeyResponse());
+
+        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.noResultsFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createEmptySearchHits());
+
+        when(mockDissolvedSearchRequests.finalFallbackQuery(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createSearchHits(true, true, true));
+
+        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits(true, true, true));
+
+        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID,
+                ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT))
+                .thenReturn(createSearchHits(true, true, true));
+
+        DissolvedSearchResults dissolvedSearchResults =
+                dissolvedSearchRequestService.getSearchResults(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(dissolvedSearchResults);
+        assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
+        assertEquals(3, dissolvedSearchResults.getItems().size());
+    }
+
+    @Test
     @DisplayName("Test search request returns results successfully with corporate name starts with query when locality missing")
     void testCorporateNameStartsWithSuccessfulMissingLocality() throws Exception{
 


### PR DESCRIPTION
The fallback query still has the chance of returning no results as it deals with exact matches. This query is for if that fails, the search term will be broken down into the first two characters and a search for the best match is sent to ES.