### PR TITLE
BI-7424 - Add in a query to the GET endpoint for previous names best match

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -69,13 +69,14 @@ public class DissolvedSearchController {
             }
         }
         LoggingUtils.getLogger().error("The search_type parameter is incorrect, please try either " +
-                "'alphabetical' or 'best-match': ", logMap);
+                "'alphabetical', 'best-match' or 'previous-name-dissolved': " , logMap);
         return apiToResponseMapper.mapDissolved(new DissolvedResponseObject(ResponseStatus.REQUEST_PARAMETER_ERROR, null));
     }
 
     private boolean checkSearchTypeParam(String searchType) {
 
         return searchType.equals(ALPHABETICAL_SEARCH_TYPE)
-                || searchType.equals(BEST_MATCH_SEARCH_TYPE);
+                || searchType.equals(BEST_MATCH_SEARCH_TYPE)
+                || searchType.equals(PREVIOUS_NAMES_SEARCH_TYPE);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -55,15 +55,9 @@ public class DissolvedSearchController {
                 return apiToResponseMapper.mapDissolved(responseObject);
             }
 
-            if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
+            if (searchType.equals(BEST_MATCH_SEARCH_TYPE) || searchType.equals(PREVIOUS_NAMES_SEARCH_TYPE)) {
                 DissolvedResponseObject responseObject = searchIndexService
-                        .searchBestMatch(companyName, requestId);
-
-                return apiToResponseMapper.mapDissolved(responseObject);
-            }
-
-            if (searchType.equals(PREVIOUS_NAMES_SEARCH_TYPE)) {
-                DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(companyName, requestId);
+                        .searchBestMatch(companyName, requestId, searchType);
 
                 return apiToResponseMapper.mapDissolved(responseObject);
             }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -33,6 +33,7 @@ public class DissolvedSearchController {
     private static final String SEARCH_TYPE_QUERY_PARAM = "search_type";
     private static final String ALPHABETICAL_SEARCH_TYPE = "alphabetical";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
+    private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
 
 
     @GetMapping("/companies")
@@ -57,6 +58,12 @@ public class DissolvedSearchController {
             if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
                 DissolvedResponseObject responseObject = searchIndexService
                         .searchBestMatch(companyName, requestId);
+
+                return apiToResponseMapper.mapDissolved(responseObject);
+            }
+
+            if (searchType.equals(PREVIOUS_NAMES_SEARCH_TYPE)) {
+                DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(companyName, requestId);
 
                 return apiToResponseMapper.mapDissolved(responseObject);
             }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.search.api.elasticsearch;
 
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
@@ -21,5 +23,13 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
 
     public QueryBuilder createBestMatchQuery(String companyName) {
         return QueryBuilders.matchQuery("company_name.doconly", companyName);
+    }
+
+    public QueryBuilder createPreviousNamesBestMatchQuery(String companyName) {
+
+        BoolQueryBuilder boolQueryBuilder =
+                QueryBuilders.boolQuery().should(QueryBuilders.matchQuery("previous_company_names.name.doconly", companyName));
+
+        return QueryBuilders.nestedQuery("previous_company_names", boolQueryBuilder, ScoreMode.Avg);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -28,6 +28,8 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
 
     private static final String INDEX = "DISSOLVED_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "DISSOLVED_SEARCH_RESULT_MAX";
+    private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
+    private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
 
     @Override
     String getIndex() {
@@ -49,31 +51,20 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
         return searchQueries;
     }
 
-    public SearchHits getDissolved(String companyName, String requestId) throws IOException {
+    public SearchHits getDissolved(String companyName, String requestId, String searchType) throws IOException {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
-        LoggingUtils.getLogger().info("Searching for best dissolved company name match", logMap);
+        LoggingUtils.getLogger().info("Searching for best dissolved company name" + searchType + "match", logMap);
 
         SearchRequest searchRequest = getBaseSearchRequest(requestId);
 
         SearchSourceBuilder sourceBuilder = getBaseSourceBuilder();
-        sourceBuilder.query(searchQueries.createBestMatchQuery(companyName));
-
-        searchRequest.source(sourceBuilder);
-
-        SearchResponse searchResponse = searchRestClient.search(searchRequest);
-        return searchResponse.getHits();
-    }
-
-    public SearchHits getPreviousNamesBestMatch(String companyName, String requestId) throws IOException {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(LoggingUtils.COMPANY_NAME, companyName);
-        LoggingUtils.getLogger().info("Searching for best dissolved company name match", logMap);
-
-        SearchRequest searchRequest = getBaseSearchRequest(requestId);
-
-        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder();
-        sourceBuilder.query(searchQueries.createPreviousNamesBestMatchQuery(companyName));
+        if (searchType.equals(BEST_MATCH_SEARCH_TYPE)){
+            sourceBuilder.query(searchQueries.createBestMatchQuery(companyName));
+        }
+        else {
+            sourceBuilder.query(searchQueries.createPreviousNamesBestMatchQuery(companyName));
+        }
 
         searchRequest.source(sourceBuilder);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -54,17 +54,45 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
         LoggingUtils.getLogger().info("Searching for best dissolved company name match", logMap);
 
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(environmentReader.getMandatoryString(getIndex()));
-        searchRequest.preference(requestId);
+        SearchRequest searchRequest = getBaseSearchRequest(requestId);
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-        sourceBuilder.size(Integer.parseInt(environmentReader.getMandatoryString(getResultsSize())));
+        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder();
         sourceBuilder.query(searchQueries.createBestMatchQuery(companyName));
 
         searchRequest.source(sourceBuilder);
 
         SearchResponse searchResponse = searchRestClient.search(searchRequest);
         return searchResponse.getHits();
+    }
+
+    public SearchHits getPreviousNamesBestMatch(String companyName, String requestId) throws IOException {
+        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
+        logMap.put(LoggingUtils.COMPANY_NAME, companyName);
+        LoggingUtils.getLogger().info("Searching for best dissolved company name match", logMap);
+
+        SearchRequest searchRequest = getBaseSearchRequest(requestId);
+
+        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder();
+        sourceBuilder.query(searchQueries.createPreviousNamesBestMatchQuery(companyName));
+
+        searchRequest.source(sourceBuilder);
+
+        SearchResponse searchResponse = searchRestClient.search(searchRequest);
+        return searchResponse.getHits();
+    }
+
+    private SearchRequest getBaseSearchRequest(String requestId) {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.indices(environmentReader.getMandatoryString(getIndex()));
+        searchRequest.preference(requestId);
+
+        return searchRequest;
+    }
+
+    private SearchSourceBuilder getBaseSourceBuilder() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(Integer.parseInt(environmentReader.getMandatoryString(getResultsSize())));
+
+        return sourceBuilder;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -29,7 +29,6 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
     private static final String INDEX = "DISSOLVED_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "DISSOLVED_SEARCH_RESULT_MAX";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
-    private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
 
     @Override
     String getIndex() {
@@ -54,7 +53,7 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
     public SearchHits getDissolved(String companyName, String requestId, String searchType) throws IOException {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
-        LoggingUtils.getLogger().info("Searching for best dissolved company name" + searchType + "match", logMap);
+        LoggingUtils.getLogger().info("Searching for best dissolved company name " + searchType + " match", logMap);
 
         SearchRequest searchRequest = getBaseSearchRequest(requestId);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -17,6 +17,7 @@ public class LoggingUtils {
     public static final String COMPANY_NUMBER = "company_number";
     public static final String DISSOLVED_SEARCH_ALPHABETICAL = "dissolved - alphabetical";
     public static final String DISSOLVED_SEARCH_BEST_MATCH = "dissolved - best match";
+    public static final String DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH = "dissolved - previous names best match";
     public static final String INDEX = "index_name";
     public static final String INDEX_ALPHABETICAL = "alphabetical_search_index";
     public static final String INDEX_DISSOLVED = "dissolved_search_index";

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -39,7 +39,7 @@ public class ApiToResponseMapper {
                 return ResponseEntity.status(NOT_FOUND).build();
             case REQUEST_PARAMETER_ERROR:
                 return ResponseEntity.status(INTERNAL_SERVER_ERROR)
-                        .body("Invalid url parameter for search_type, please try 'alphabetical' or 'best-match'");
+                        .body("Invalid url parameter for search_type, please try 'alphabetical', 'best-match' or 'previous-name-dissolved'");
             default:
                 return ResponseEntity.status(INTERNAL_SERVER_ERROR).build();
         }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -26,7 +26,6 @@ public class DissolvedSearchIndexService {
     private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
     private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
-    private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
 
     public DissolvedResponseObject searchAlphabetical(String companyName, String requestId) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
@@ -57,7 +56,7 @@ public class DissolvedSearchIndexService {
 
     public DissolvedResponseObject searchBestMatch(String companyName, String requestId, String searchType) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        if (searchType == BEST_MATCH_SEARCH_TYPE) {
+        if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
             logMap.put(COMPANY_NAME, companyName);
             logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
             logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
@@ -73,7 +72,7 @@ public class DissolvedSearchIndexService {
 
         DissolvedSearchResults searchResults;
         try {
-            if (searchType == BEST_MATCH_SEARCH_TYPE) {
+            if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
                 searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
             }
             else {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -72,12 +72,7 @@ public class DissolvedSearchIndexService {
 
         DissolvedSearchResults searchResults;
         try {
-            if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
-                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
-            }
-            else {
-                searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
-            }
+                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId, searchType);
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
                             "best matches on a" + searchType + " dissolved company: ",

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -74,4 +74,31 @@ public class DissolvedSearchIndexService {
                 "best match on a dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
+
+    public DissolvedResponseObject searchPreviousNamesBestMatch(String companyName, String requestId) {
+        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
+        logMap.put(COMPANY_NAME, companyName);
+        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
+        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
+        LoggingUtils.getLogger().info("searching for company", logMap);
+
+        DissolvedSearchResults searchResults;
+        try {
+            searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
+        } catch (SearchException e) {
+            LoggingUtils.getLogger().error("An error occurred while trying to search for " +
+                            "best matches on a dissolved company: ",
+                    logMap);
+            return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
+        }
+
+        if (searchResults.getItems() != null) {
+            LoggingUtils.getLogger().info("successful best match search for dissolved company", logMap);
+            return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
+        }
+
+        LoggingUtils.getLogger().info("No results were returned while searching for " +
+                "best match on a dissolved company", logMap);
+        return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -12,8 +12,6 @@ import java.util.Map;
 
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_ALPHABETICAL;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_BEST_MATCH;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SEARCH_TYPE;
 
 @Service
@@ -25,14 +23,9 @@ public class DissolvedSearchIndexService {
     private static final String SEARCHING_FOR_COMPANY_INFO = "searching for company";
     private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
     private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
-    private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
 
     public DissolvedResponseObject searchAlphabetical(String companyName, String requestId) {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(COMPANY_NAME, companyName);
-        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_ALPHABETICAL);
-        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
+        Map<String, Object> logMap = getLogMap(companyName, requestId, DISSOLVED_SEARCH_ALPHABETICAL);
 
         DissolvedSearchResults searchResults;
         try {
@@ -55,38 +48,35 @@ public class DissolvedSearchIndexService {
     }
 
     public DissolvedResponseObject searchBestMatch(String companyName, String requestId, String searchType) {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
-            logMap.put(COMPANY_NAME, companyName);
-            logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
-            logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-            LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
-        }
-
-        else {
-            logMap.put(COMPANY_NAME, companyName);
-            logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH);
-            logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-            LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
-        }
+        Map<String, Object> logMap = getLogMap(companyName, requestId, searchType);
 
         DissolvedSearchResults searchResults;
         try {
-                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId, searchType);
+            searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId, searchType);
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
-                            "best matches on a" + searchType + " dissolved company: ",
+                            "best matches on a " + searchType + " dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
         if (searchResults.getItems() != null) {
-            LoggingUtils.getLogger().info("successful best match search for" + searchType + " dissolved company", logMap);
+            LoggingUtils.getLogger().info("successful best match search for " + searchType + " dissolved company", logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
         LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
-                "best match on a" + searchType + " dissolved company", logMap);
+                "best match on a " + searchType + " dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
+    }
+
+    private Map<String, Object> getLogMap(String companyName, String requestId, String searchType) {
+        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
+        logMap.put(COMPANY_NAME, companyName);
+        logMap.put(SEARCH_TYPE, searchType);
+        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
+        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
+
+        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -92,18 +92,18 @@ public class DissolvedSearchIndexService {
             searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
-                            "best matches on a dissolved company: ",
+                            "best matches for previous company name on a dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
         if (searchResults.getItems() != null) {
-            LoggingUtils.getLogger().info("successful best match search for dissolved company", logMap);
+            LoggingUtils.getLogger().info("successful best match search for previous company name on a dissolved company", logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
         LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
-                "best match on a dissolved company", logMap);
+                "best match search for previous company name on a dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -64,15 +64,11 @@ public class DissolvedSearchIndexService {
             LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
         }
 
-        if (searchType == PREVIOUS_NAMES_SEARCH_TYPE) {
+        else {
             logMap.put(COMPANY_NAME, companyName);
             logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH);
             logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
             LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
-        }
-        else {
-            LoggingUtils.getLogger().error("The search_type parameter is incorrect, please try either " +
-            "'best-match' or 'previous-name-dissolved': " , logMap);
         }
 
         DissolvedSearchResults searchResults;
@@ -80,12 +76,8 @@ public class DissolvedSearchIndexService {
             if (searchType == BEST_MATCH_SEARCH_TYPE) {
                 searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
             }
-            if (searchType == PREVIOUS_NAMES_SEARCH_TYPE) {
-                searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
-            }
             else {
-                LoggingUtils.getLogger().error("The search_type parameter is incorrect, please try either " +
-                "'best-match' or 'previous-name-dissolved': " , logMap);
+                searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
             }
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_ALPHABETICAL;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_BEST_MATCH;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SEARCH_TYPE;
 
 @Service
@@ -21,18 +22,22 @@ public class DissolvedSearchIndexService {
     @Autowired
     private DissolvedSearchRequestService dissolvedSearchRequestService;
 
+    private static final String SEARCHING_FOR_COMPANY_INFO = "searching for company";
+    private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
+    private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
+
     public DissolvedResponseObject searchAlphabetical(String companyName, String requestId) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(COMPANY_NAME, companyName);
         logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_ALPHABETICAL);
         logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("searching for company", logMap);
+        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
 
         DissolvedSearchResults searchResults;
         try {
             searchResults = dissolvedSearchRequestService.getSearchResults(companyName, requestId);
         } catch (SearchException e) {
-            LoggingUtils.getLogger().error("An error occurred while trying to search for " +
+            LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
                             "alphabetical results on a dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
@@ -43,7 +48,7 @@ public class DissolvedSearchIndexService {
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
-        LoggingUtils.getLogger().info("No results were returned while searching for " +
+        LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
                 "alphabetical results on a dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
@@ -53,13 +58,13 @@ public class DissolvedSearchIndexService {
         logMap.put(COMPANY_NAME, companyName);
         logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
         logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("searching for company", logMap);
+        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
 
         DissolvedSearchResults searchResults;
         try {
             searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
         } catch (SearchException e) {
-            LoggingUtils.getLogger().error("An error occurred while trying to search for " +
+            LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
                             "best matches on a dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
@@ -70,7 +75,7 @@ public class DissolvedSearchIndexService {
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
-        LoggingUtils.getLogger().info("No results were returned while searching for " +
+        LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
                 "best match on a dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
@@ -78,15 +83,15 @@ public class DissolvedSearchIndexService {
     public DissolvedResponseObject searchPreviousNamesBestMatch(String companyName, String requestId) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(COMPANY_NAME, companyName);
-        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
+        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH);
         logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("searching for company", logMap);
+        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
 
         DissolvedSearchResults searchResults;
         try {
-            searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
+            searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
         } catch (SearchException e) {
-            LoggingUtils.getLogger().error("An error occurred while trying to search for " +
+            LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
                             "best matches on a dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
@@ -97,7 +102,7 @@ public class DissolvedSearchIndexService {
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
-        LoggingUtils.getLogger().info("No results were returned while searching for " +
+        LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
                 "best match on a dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -25,6 +25,8 @@ public class DissolvedSearchIndexService {
     private static final String SEARCHING_FOR_COMPANY_INFO = "searching for company";
     private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
     private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
+    private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
+    private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
 
     public DissolvedResponseObject searchAlphabetical(String companyName, String requestId) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
@@ -53,57 +55,44 @@ public class DissolvedSearchIndexService {
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
 
-    public DissolvedResponseObject searchBestMatch(String companyName, String requestId) {
+    public DissolvedResponseObject searchBestMatch(String companyName, String requestId, String searchType) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(COMPANY_NAME, companyName);
-        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
-        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
+        if (searchType == BEST_MATCH_SEARCH_TYPE) {
+            logMap.put(COMPANY_NAME, companyName);
+            logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_BEST_MATCH);
+            logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
+            LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
+        }
+
+        if (searchType == PREVIOUS_NAMES_SEARCH_TYPE) {
+            logMap.put(COMPANY_NAME, companyName);
+            logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH);
+            logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
+            LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
+        }
 
         DissolvedSearchResults searchResults;
         try {
-            searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
+            if (searchType == BEST_MATCH_SEARCH_TYPE) {
+                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId);
+            }
+            if (searchType == PREVIOUS_NAMES_SEARCH_TYPE) {
+                searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
+            }
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
-                            "best matches on a dissolved company: ",
+                            "best matches on a" + searchType + " dissolved company: ",
                     logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
         if (searchResults.getItems() != null) {
-            LoggingUtils.getLogger().info("successful best match search for dissolved company", logMap);
+            LoggingUtils.getLogger().info("successful best match search for" + searchType + " dissolved company", logMap);
             return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
 
         LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
-                "best match on a dissolved company", logMap);
-        return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
-    }
-
-    public DissolvedResponseObject searchPreviousNamesBestMatch(String companyName, String requestId) {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(COMPANY_NAME, companyName);
-        logMap.put(SEARCH_TYPE, DISSOLVED_SEARCH_PREVIOUS_NAMES_BEST_MATCH);
-        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
-
-        DissolvedSearchResults searchResults;
-        try {
-            searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
-        } catch (SearchException e) {
-            LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +
-                            "best matches for previous company name on a dissolved company: ",
-                    logMap);
-            return new DissolvedResponseObject(ResponseStatus.SEARCH_ERROR, null);
-        }
-
-        if (searchResults.getItems() != null) {
-            LoggingUtils.getLogger().info("successful best match search for previous company name on a dissolved company", logMap);
-            return new DissolvedResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
-        }
-
-        LoggingUtils.getLogger().info(NO_RESULTS_FOUND +
-                "best match search for previous company name on a dissolved company", logMap);
+                "best match on a" + searchType + " dissolved company", logMap);
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -70,6 +70,10 @@ public class DissolvedSearchIndexService {
             logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
             LoggingUtils.getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
         }
+        else {
+            LoggingUtils.getLogger().error("The search_type parameter is incorrect, please try either " +
+            "'best-match' or 'previous-name-dissolved': " , logMap);
+        }
 
         DissolvedSearchResults searchResults;
         try {
@@ -78,6 +82,10 @@ public class DissolvedSearchIndexService {
             }
             if (searchType == PREVIOUS_NAMES_SEARCH_TYPE) {
                 searchResults = dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(companyName, requestId);
+            }
+            else {
+                LoggingUtils.getLogger().error("The search_type parameter is incorrect, please try either " +
+                "'best-match' or 'previous-name-dissolved': " , logMap);
             }
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -38,6 +38,7 @@ public class DissolvedSearchRequestService {
     private static final String SEARCH_RESULTS_KIND = "searchresults#dissolvedCompany";
     private static final String TOP_KIND = "search#alphabetical-dissolved";
     private static final int FALLBACK_QUERY_LIMIT = 25;
+    private static final String RESULT_FOUND = "A result has been found";
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);
 
@@ -68,7 +69,7 @@ public class DissolvedSearchRequestService {
             }
 
             if (hits.getTotalHits().value > 0) {
-                LoggingUtils.getLogger().info("A result has been found", logMap);
+                LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
 
                 String orderedAlphaKeyWithId;
                 SearchHit bestMatch;
@@ -106,7 +107,7 @@ public class DissolvedSearchRequestService {
             SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId);
 
             if (hits.getTotalHits().value > 0) {
-                LoggingUtils.getLogger().info("A result has been found", logMap);
+                LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
 
                 DissolvedCompany topHitCompany = mapESResponse(hits.getHits()[0]);
 
@@ -137,7 +138,7 @@ public class DissolvedSearchRequestService {
             SearchHits hits  = dissolvedSearchRequests.getPreviousNamesBestMatch(companyName, requestId);
 
             if (hits.getTotalHits().value > 0) {
-                LoggingUtils.getLogger().info("A result has been found", logMap);
+                LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
 
                 DissolvedCompany topHitCompany = mapESResponse(hits.getHits()[0]);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -94,18 +94,18 @@ public class DissolvedSearchRequestService {
         return new DissolvedSearchResults(etag, topHit, results, kind);
     }
 
-    public DissolvedSearchResults getBestMatchSearchResults(String companyName, String requestId) throws SearchException {
+    public DissolvedSearchResults getBestMatchSearchResults(String companyName, String requestId, String searchType) throws SearchException {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
         logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("getting dissolved best match search results", logMap);
+        LoggingUtils.getLogger().info("getting dissolved" + searchType + "search results", logMap);
 
         String etag = GenerateEtagUtil.generateEtag();
         DissolvedTopHit topHit = new DissolvedTopHit();
         List<DissolvedCompany> results = new ArrayList<>();
 
         try {
-            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId);
+            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType);
 
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
@@ -126,14 +126,7 @@ public class DissolvedSearchRequestService {
     }
 
     public DissolvedSearchResults getPreviousNamesBestMatchSearchResults(String companyName, String requestId) throws SearchException {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(LoggingUtils.COMPANY_NAME, companyName);
-        logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("getting dissolved previous names best match search results", logMap);
 
-        String etag = GenerateEtagUtil.generateEtag();
-        DissolvedTopHit topHit = new DissolvedTopHit();
-        List<DissolvedCompany> results = new ArrayList<>();
 
         try {
             SearchHits hits  = dissolvedSearchRequests.getPreviousNamesBestMatch(companyName, requestId);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -41,6 +41,7 @@ public class DissolvedSearchRequestService {
     private static final String RESULT_FOUND = "A result has been found";
     private static final String SEARCH_HITS = "searchHits";
 
+
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);
 
     public DissolvedSearchResults getSearchResults(String companyName, String requestId) throws SearchException {
@@ -98,13 +99,14 @@ public class DissolvedSearchRequestService {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
         logMap.put(LoggingUtils.INDEX, LoggingUtils.INDEX_DISSOLVED);
-        LoggingUtils.getLogger().info("getting dissolved" + searchType + "search results", logMap);
+        LoggingUtils.getLogger().info("getting dissolved " + searchType + " search results", logMap);
 
         String etag = GenerateEtagUtil.generateEtag();
         DissolvedTopHit topHit = new DissolvedTopHit();
         List<DissolvedCompany> results = new ArrayList<>();
 
         try {
+
             SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType);
 
             if (hits.getTotalHits().value > 0) {
@@ -119,30 +121,6 @@ public class DissolvedSearchRequestService {
         } catch (IOException e) {
             LoggingUtils.getLogger().error("failed to get best match for dissolved company",
                 logMap);
-            throw new SearchException("error occurred reading data for best match from " + SEARCH_HITS, e);
-        }
-
-        return new DissolvedSearchResults(etag, topHit, results, "search#dissolved");
-    }
-
-    public DissolvedSearchResults getPreviousNamesBestMatchSearchResults(String companyName, String requestId) throws SearchException {
-
-
-        try {
-            SearchHits hits  = dissolvedSearchRequests.getPreviousNamesBestMatch(companyName, requestId);
-
-            if (hits.getTotalHits().value > 0) {
-                LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
-
-                DissolvedCompany topHitCompany = mapESResponse(hits.getHits()[0]);
-
-                mapTopHit(topHit, topHitCompany);
-
-                hits.forEach(h -> results.add(mapESResponse(h)));
-            }
-        } catch (IOException e) {
-            LoggingUtils.getLogger().error("failed to get best match for dissolved company",
-                    logMap);
             throw new SearchException("error occurred reading data for best match from " + SEARCH_HITS, e);
         }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -39,6 +39,7 @@ public class DissolvedSearchRequestService {
     private static final String TOP_KIND = "search#alphabetical-dissolved";
     private static final int FALLBACK_QUERY_LIMIT = 25;
     private static final String RESULT_FOUND = "A result has been found";
+    private static final String SEARCH_HITS = "searchHits";
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);
 
@@ -87,7 +88,7 @@ public class DissolvedSearchRequestService {
         } catch (IOException e) {
             LoggingUtils.getLogger().error("failed to map highest map to company object",
                 logMap);
-            throw new SearchException("error occurred reading data for highest match from " + "searchHits", e);
+            throw new SearchException("error occurred reading data for highest match from " + SEARCH_HITS, e);
         }
 
         return new DissolvedSearchResults(etag, topHit, results, kind);
@@ -118,7 +119,7 @@ public class DissolvedSearchRequestService {
         } catch (IOException e) {
             LoggingUtils.getLogger().error("failed to get best match for dissolved company",
                 logMap);
-            throw new SearchException("error occurred reading data for best match from " + "searchHits", e);
+            throw new SearchException("error occurred reading data for best match from " + SEARCH_HITS, e);
         }
 
         return new DissolvedSearchResults(etag, topHit, results, "search#dissolved");
@@ -149,7 +150,7 @@ public class DissolvedSearchRequestService {
         } catch (IOException e) {
             LoggingUtils.getLogger().error("failed to get best match for dissolved company",
                     logMap);
-            throw new SearchException("error occurred reading data for best match from " + "searchHits", e);
+            throw new SearchException("error occurred reading data for best match from " + SEARCH_HITS, e);
         }
 
         return new DissolvedSearchResults(etag, topHit, results, "search#dissolved");

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -44,6 +44,7 @@ class DissolvedSearchControllerTest {
     private static final String COMPANY_NAME = "test company";
     private static final String SEARCH_TYPE_ALPHABETICAL = "alphabetical";
     private static final String SEARCH_TYPE_BEST_MATCH = "best-match";
+    private static final String SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH = "previous-name-dissolved";
     private static final String COMPANY_NUMBER = "00000000";
 
     @Test
@@ -77,6 +78,24 @@ class DissolvedSearchControllerTest {
 
         ResponseEntity responseEntity =
                 dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_BEST_MATCH, REQUEST_ID);
+
+        assertNotNull(responseEntity);
+        assertEquals(FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test previous names best match for dissolved found")
+    void testPreviousNamesBestMatchForDissolvedFound() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
+
+        when(mockSearchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID)).thenReturn(responseObject);
+        when(mockApiToResponseMapper.mapDissolved(responseObject))
+                .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
+
+        ResponseEntity responseEntity =
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(FOUND, responseEntity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.REQUEST_PARAMETER_ERROR;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -72,7 +72,7 @@ class DissolvedSearchControllerTest {
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
 
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID)).thenReturn(responseObject);
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH)).thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
@@ -90,7 +90,7 @@ class DissolvedSearchControllerTest {
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
 
-        when(mockSearchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID)).thenReturn(responseObject);
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH)).thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueriesTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueriesTest.java
@@ -54,4 +54,13 @@ class DissolvedSearchQueriesTest {
 
         assertNotNull(queryBuilder);
     }
+
+    @Test
+    @DisplayName("Create previous names best match query")
+    void createPreviousNamesBestMatchQuery() {
+        QueryBuilder queryBuilder =
+                dissolvedSearchQueries.createPreviousNamesBestMatchQuery("company name");
+
+        assertNotNull(queryBuilder);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -139,7 +139,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-                .getPreviousNamesBestMatch("companyName", "requestId");
+                .getDissolved("companyName", "requestId", "searchType");
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -118,14 +118,28 @@ class DissolvedSearchRequestsTest {
     }
 
     @Test
-    @DisplayName("Get dissolved response")
-    void getDissolvedhResponse() throws Exception {
+    @DisplayName("Get dissolved search best match response")
+    void getDissolvedSearchBestMatchResponse() throws Exception {
 
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
             .getDissolved("orderedAlpha", "requestId");
+
+        assertNotNull(searchHits);
+        assertEquals(1, searchHits.getTotalHits().value);
+    }
+
+    @Test
+    @DisplayName("Get dissolved search previous names best match response")
+    void getDissolvedSearchPreviousNamesResponse() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
+        when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+
+        SearchHits searchHits = dissolvedSearchRequests
+                .getPreviousNamesBestMatch("companyName", "requestId");
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -125,7 +125,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-            .getDissolved("orderedAlpha", "requestId");
+            .getDissolved("orderedAlpha", "requestId", "searchType");
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapperTest.java
@@ -158,7 +158,7 @@ class ApiToResponseMapperTest {
 
         assertNotNull(responseEntity);
         assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
-        assertEquals("Invalid url parameter for search_type, please try 'alphabetical' or 'best-match'", responseEntity.getBody().toString());
+        assertEquals("Invalid url parameter for search_type, please try 'alphabetical', 'best-match' or 'previous-name-dissolved'", responseEntity.getBody());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -118,6 +118,40 @@ class DissolvedSearchIndexServiceTest {
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
     }
 
+    @Test
+    @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
+    void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
+        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+                .thenReturn(createSearchResults(true));
+        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
+    }
+
+    @Test
+    @DisplayName("Test best match for previous company names on a dissolved search returns an error")
+    void searchBestMatchPreviousNamesDissolvedRequestReturnsError() throws Exception {
+        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+                .thenThrow(SearchException.class);
+
+        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
+    }
+
+    @Test
+    @DisplayName("Test best match for previous company names on a dissolved search returns no results")
+    void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
+        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+                .thenReturn(createSearchResults(false));
+        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
+    }
+
     private DissolvedSearchResults createSearchResults(boolean isResultsPopulated) {
         DissolvedSearchResults searchResults = new DissolvedSearchResults();
         TopHit topHit = new TopHit();

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -48,6 +48,8 @@ class DissolvedSearchIndexServiceTest {
     private static final String POSTAL_CODE = "AB12 C34";
     private static final String PREVIOUS_NAME = "previousName";
     private static final String KIND = "searchresults#dissolvedCompany";
+    private static final String SEARCH_TYPE_BEST_MATCH = "best-match";
+    private static final String SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH = "previous-name-dissolved";
 
 
     @Test
@@ -89,7 +91,7 @@ class DissolvedSearchIndexServiceTest {
     void searchBestMatchDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenReturn(createSearchResults(true));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -101,7 +103,7 @@ class DissolvedSearchIndexServiceTest {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenThrow(SearchException.class);
 
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -112,7 +114,7 @@ class DissolvedSearchIndexServiceTest {
     void searchBestMatchDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenReturn(createSearchResults(false));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -123,7 +125,7 @@ class DissolvedSearchIndexServiceTest {
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenReturn(createSearchResults(true));
-        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -135,7 +137,7 @@ class DissolvedSearchIndexServiceTest {
         when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenThrow(SearchException.class);
 
-        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -146,7 +148,7 @@ class DissolvedSearchIndexServiceTest {
     void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
                 .thenReturn(createSearchResults(false));
-        DissolvedResponseObject responseObject = searchIndexService.searchPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -89,7 +89,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search request returns successfully")
     void searchBestMatchDissolvedRequestSuccessful() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
                 .thenReturn(createSearchResults(true));
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
@@ -100,7 +100,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search returns an error")
     void searchBestMatchDissolvedRequestReturnsError() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
                 .thenThrow(SearchException.class);
 
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
@@ -112,7 +112,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search returns no results")
     void searchBestMatchDissolvedRequestReturnsNoResults() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
                 .thenReturn(createSearchResults(false));
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
@@ -124,7 +124,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
                 .thenReturn(createSearchResults(true));
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 
@@ -135,7 +135,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search returns an error")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsError() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
                 .thenThrow(SearchException.class);
 
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
@@ -147,7 +147,7 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search returns no results")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
                 .thenReturn(createSearchResults(false));
         DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -120,6 +120,7 @@ class DissolvedSearchIndexServiceTest {
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
     }
 
+    //PREVIOUS
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -286,13 +286,13 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test best match search results successful")
     void testBestMatchSuccessful() throws Exception {
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID,)).
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID,SEARCH_TYPE_BEST_MATCH)).
             thenReturn(createSearchHits(true,true,true, true));
 
 
 
         DissolvedSearchResults dissolvedSearchResults =
-                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID);
+                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
 
         assertEquals("search#dissolved", dissolvedSearchResults.getKind());
         assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -319,7 +319,7 @@ class DissolvedSearchRequestServiceTest {
 
 
         DissolvedSearchResults dissolvedSearchResults =
-                dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID);
+                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
 
         assertEquals("search#dissolved", dissolvedSearchResults.getKind());
         assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -329,11 +329,11 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test get best match previous names search request throws exception")
     void testBestMatchPreviousNamesThrowException() throws Exception{
 
-        when(mockDissolvedSearchRequests.getPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
                 .thenThrow(IOException.class);
 
         assertThrows(SearchException.class, () ->
-                dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID));
+                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -48,6 +48,8 @@ class DissolvedSearchRequestServiceTest {
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
     private static final String REQUEST_ID = "requestId";
     private static final String DISSOLVED_ALPHABETICAL_KIND = "search#alphabetical-dissolved";
+    private static final String SEARCH_TYPE_BEST_MATCH = "best-match";
+    private static final String SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH = "previous-name-dissolved";
 
     @Test
     @DisplayName("Test search request returns results successfully with best match query")
@@ -284,7 +286,7 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test best match search results successful")
     void testBestMatchSuccessful() throws Exception {
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID)).
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID,)).
             thenReturn(createSearchHits(true,true,true, true));
 
 
@@ -300,18 +302,18 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test get best match search request throws exception")
     void testBestMatchThrowException() throws Exception{
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID))
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
             .thenThrow(IOException.class);
 
         assertThrows(SearchException.class, () ->
-            dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID));
+            dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH));
     }
 
     @Test
     @DisplayName("Test best match previous names search results successful")
     void testBestMatchPreviousNamesSuccessful() throws Exception {
 
-        when(mockDissolvedSearchRequests.getPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID)).
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH)).
                 thenReturn(createSearchHits(true,true,true, true));
 
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -308,6 +308,33 @@ class DissolvedSearchRequestServiceTest {
     }
 
     @Test
+    @DisplayName("Test best match previous names search results successful")
+    void testBestMatchPreviousNamesSuccessful() throws Exception {
+
+        when(mockDissolvedSearchRequests.getPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID)).
+                thenReturn(createSearchHits(true,true,true, true));
+
+
+
+        DissolvedSearchResults dissolvedSearchResults =
+                dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID);
+
+        assertEquals("search#dissolved", dissolvedSearchResults.getKind());
+        assertEquals(TOP_HIT, dissolvedSearchResults.getTopHit().getCompanyName());
+    }
+
+    @Test
+    @DisplayName("Test get best match previous names search request throws exception")
+    void testBestMatchPreviousNamesThrowException() throws Exception{
+
+        when(mockDissolvedSearchRequests.getPreviousNamesBestMatch(COMPANY_NAME, REQUEST_ID))
+                .thenThrow(IOException.class);
+
+        assertThrows(SearchException.class, () ->
+                dissolvedSearchRequestService.getPreviousNamesBestMatchSearchResults(COMPANY_NAME, REQUEST_ID));
+    }
+
+    @Test
     @DisplayName("Test peelbackSearchRequest successful")
     void testPeelbackSearchRequestSuccessful() throws Exception {
 


### PR DESCRIPTION
- Add new query parameter to enable previous company names best match search
- Add request to return results from the dissolved search index
- Add first iteration query for previous company names best match search
- Increase code coverage

Resolves: BI-7424