### PR TITLE
Use a match phrase prefix query to enhance results returned

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -20,6 +20,6 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
     }
 
     public QueryBuilder createBestMatchQuery(String companyName) {
-        return QueryBuilders.matchQuery("company_name.doconly", companyName);
+        return QueryBuilders.matchPhrasePrefixQuery("company_name.company_name_phrase", companyName).slop(1);
     }
 }


### PR DESCRIPTION
- Use a match phrase prefix query to take into consideration the order of the words in the search query.

Resolves: BI-7450