### PR TITLE
BI-7515, BI-7516 - Update API to enable paging for dissolved search best match and previous names

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchController.java
@@ -31,6 +31,7 @@ public class DissolvedSearchController {
     private static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
     private static final String COMPANY_NAME_QUERY_PARAM = "q";
     private static final String SEARCH_TYPE_QUERY_PARAM = "search_type";
+    private static final String START_INDEX_QUERY_PARAM = "start_index";
     private static final String ALPHABETICAL_SEARCH_TYPE = "alphabetical";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
     private static final String PREVIOUS_NAMES_SEARCH_TYPE = "previous-name-dissolved";
@@ -40,6 +41,7 @@ public class DissolvedSearchController {
     @ResponseBody
     public ResponseEntity<Object> searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
                                                   @RequestParam(name = SEARCH_TYPE_QUERY_PARAM) String searchType,
+                                                  @RequestParam(name = START_INDEX_QUERY_PARAM, required = false) Integer startIndex,
                                                   @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
@@ -56,8 +58,13 @@ public class DissolvedSearchController {
             }
 
             if (searchType.equals(BEST_MATCH_SEARCH_TYPE) || searchType.equals(PREVIOUS_NAMES_SEARCH_TYPE)) {
+
+                if (startIndex == null || startIndex < 0) {
+                    startIndex = 0;
+                }
+
                 DissolvedResponseObject responseObject = searchIndexService
-                        .searchBestMatch(companyName, requestId, searchType);
+                        .searchBestMatch(companyName, requestId, searchType, startIndex);
 
                 return apiToResponseMapper.mapDissolved(responseObject);
             }

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -51,14 +51,17 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
         return searchQueries;
     }
 
-    public SearchHits getDissolved(String companyName, String requestId, String searchType) throws IOException {
+    public SearchHits getDissolved(String companyName,
+                                   String requestId,
+                                   String searchType,
+                                   Integer startIndex) throws IOException {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
         LoggingUtils.getLogger().info("Searching for best dissolved company name " + searchType + " match", logMap);
 
         SearchRequest searchRequest = getBaseSearchRequest(requestId);
 
-        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder();
+        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder(startIndex);
         if (searchType.equals(BEST_MATCH_SEARCH_TYPE)){
             sourceBuilder.query(searchQueries.createBestMatchQuery(companyName));
         }
@@ -83,9 +86,10 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
         return searchRequest;
     }
 
-    private SearchSourceBuilder getBaseSourceBuilder() {
+    private SearchSourceBuilder getBaseSourceBuilder(Integer startIndex) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         sourceBuilder.size(Integer.parseInt(environmentReader.getMandatoryString(getResultsSize())));
+        sourceBuilder.from(startIndex);
 
         return sourceBuilder;
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/DissolvedSearchResults.java
@@ -1,9 +1,11 @@
 package uk.gov.companieshouse.search.api.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DissolvedSearchResults<T> {
 
     @JsonProperty("etag")
@@ -17,6 +19,9 @@ public class DissolvedSearchResults<T> {
 
     @JsonProperty("kind")
     private String kind;
+
+    @JsonProperty("hits")
+    private Long hits;
 
     public DissolvedSearchResults() {
     }
@@ -58,5 +63,13 @@ public class DissolvedSearchResults<T> {
 
     public void setKind(String kind) {
         this.kind = kind;
+    }
+
+    public Long getHits() {
+        return hits;
+    }
+
+    public void setHits(Long hits) {
+        this.hits = hits;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -48,15 +48,15 @@ public class DissolvedSearchIndexService {
         return new DissolvedResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
     }
 
-    public DissolvedResponseObject searchBestMatch(String companyName, String requestId, String searchType) {
+    public DissolvedResponseObject searchBestMatch(String companyName, String requestId, String searchType, Integer startIndex) {
         Map<String, Object> logMap = getLogMap(companyName, requestId, searchType);
 
         DissolvedSearchResults searchResults;
         try {
             if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
-                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId, searchType);
+                searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId, searchType, startIndex);
             } else {
-                searchResults = dissolvedSearchRequestService.getPreviousNamesResults(companyName, requestId, searchType);
+                searchResults = dissolvedSearchRequestService.getPreviousNamesResults(companyName, requestId, searchType, startIndex);
             }
         } catch (SearchException e) {
             LoggingUtils.getLogger().error(STANDARD_ERROR_MESSAGE +

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -90,7 +90,7 @@ public class DissolvedSearchRequestService {
         return new DissolvedSearchResults(etag, topHit, results, kind);
     }
 
-    public DissolvedSearchResults getBestMatchSearchResults(String companyName,
+    public DissolvedSearchResults<DissolvedCompany> getBestMatchSearchResults(String companyName,
                                                             String requestId,
                                                             String searchType,
                                                             Integer startIndex) throws SearchException {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -142,9 +142,11 @@ public class DissolvedSearchRequestService {
         PreviousNamesTopHit topHit = new PreviousNamesTopHit();
         List<DissolvedPreviousName> results = new ArrayList<>();
         String kind = "search#previous-name-dissolved";
+        long numberOfHits;
 
         try {
             SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
+            numberOfHits = hits.getTotalHits().value;
 
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
@@ -159,7 +161,11 @@ public class DissolvedSearchRequestService {
             throw new SearchException("error occurred reading data for previous names from " + SEARCH_HITS, e);
         }
 
-        return new DissolvedSearchResults<>(etag, topHit, results, kind);
+        DissolvedSearchResults<DissolvedPreviousName> dissolvedSearchResults =
+                new DissolvedSearchResults<>(etag, topHit, results, kind);
+        dissolvedSearchResults.setHits(numberOfHits);
+
+        return dissolvedSearchResults;
     }
 
     private SearchHits getSearchHits(String orderedAlphakey, String requestId) throws IOException {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -90,7 +90,10 @@ public class DissolvedSearchRequestService {
         return new DissolvedSearchResults(etag, topHit, results, kind);
     }
 
-    public DissolvedSearchResults getBestMatchSearchResults(String companyName, String requestId, String searchType) throws SearchException {
+    public DissolvedSearchResults getBestMatchSearchResults(String companyName,
+                                                            String requestId,
+                                                            String searchType,
+                                                            Integer startIndex) throws SearchException {
         Map<String, Object> logMap = getLogMap(requestId, companyName);
         LoggingUtils.getLogger().info("getting dissolved " + searchType + " search results", logMap);
 
@@ -101,7 +104,7 @@ public class DissolvedSearchRequestService {
 
         try {
 
-            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType);
+            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
 
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
@@ -121,8 +124,10 @@ public class DissolvedSearchRequestService {
         return new DissolvedSearchResults(etag, topHit, results, kind);
     }
 
-    public DissolvedSearchResults<DissolvedPreviousName> getPreviousNamesResults(String companyName, String requestId,
-                                                                               String searchType) throws SearchException {
+    public DissolvedSearchResults<DissolvedPreviousName> getPreviousNamesResults(String companyName,
+                                                                                 String requestId,
+                                                                                 String searchType,
+                                                                                 Integer startIndex) throws SearchException {
 
         Map<String, Object> logMap = getLogMap(requestId, companyName);
         LoggingUtils.getLogger().info("getting dissolved " + searchType + " search results", logMap);
@@ -133,7 +138,7 @@ public class DissolvedSearchRequestService {
         String kind = "search#previous-name-dissolved";
 
         try {
-            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType);
+            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
 
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info(RESULT_FOUND, logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -101,10 +101,12 @@ public class DissolvedSearchRequestService {
         DissolvedTopHit topHit= new DissolvedTopHit();
         List<DissolvedCompany> results = new ArrayList<>();
         String kind = "search#dissolved";
+        long numberOfHits;
 
         try {
 
             SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
+            numberOfHits = hits.getTotalHits().value;
 
             if (hits.getTotalHits().value > 0) {
                 LoggingUtils.getLogger().info(RESULT_FOUND, logMap);
@@ -121,7 +123,11 @@ public class DissolvedSearchRequestService {
             throw new SearchException("error occurred reading data for best match from " + SEARCH_HITS, e);
         }
 
-        return new DissolvedSearchResults(etag, topHit, results, kind);
+        DissolvedSearchResults<DissolvedCompany> dissolvedSearchResults =
+                new DissolvedSearchResults<>(etag, topHit, results, kind);
+        dissolvedSearchResults.setHits(numberOfHits);
+
+        return dissolvedSearchResults;
     }
 
     public DissolvedSearchResults<DissolvedPreviousName> getPreviousNamesResults(String companyName,

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -45,6 +45,8 @@ class DissolvedSearchControllerTest {
     private static final String SEARCH_TYPE_BEST_MATCH = "best-match";
     private static final String SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH = "previous-name-dissolved";
     private static final String COMPANY_NUMBER = "00000000";
+    private static final Integer START_INDEX = 0;
+    private static final Integer START_INDEX_LESS_THAN_ZERO = -1;
 
     @Test
     @DisplayName("Test alphabetical search for dissolved found")
@@ -58,7 +60,7 @@ class DissolvedSearchControllerTest {
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
         ResponseEntity responseEntity =
-                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_ALPHABETICAL, REQUEST_ID);
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_ALPHABETICAL, START_INDEX, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(FOUND, responseEntity.getStatusCode());
@@ -71,12 +73,48 @@ class DissolvedSearchControllerTest {
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
 
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH)).thenReturn(responseObject);
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
         ResponseEntity responseEntity =
-                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_BEST_MATCH, REQUEST_ID);
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_BEST_MATCH, START_INDEX, REQUEST_ID);
+
+        assertNotNull(responseEntity);
+        assertEquals(FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test best match for dissolved found without providing start index")
+    void testBestMatchForDissolvedFoundNoStartIndex() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
+
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(responseObject);
+        when(mockApiToResponseMapper.mapDissolved(responseObject))
+                .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
+
+        ResponseEntity responseEntity =
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_BEST_MATCH, null, REQUEST_ID);
+
+        assertNotNull(responseEntity);
+        assertEquals(FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test best match for dissolved found with start index out of bounds")
+    void testBestMatchForDissolvedFoundStartIndexOutOfBounds() {
+
+        DissolvedResponseObject responseObject =
+                new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
+
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(responseObject);
+        when(mockApiToResponseMapper.mapDissolved(responseObject))
+                .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
+
+        ResponseEntity responseEntity =
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_BEST_MATCH, -1, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(FOUND, responseEntity.getStatusCode());
@@ -89,12 +127,12 @@ class DissolvedSearchControllerTest {
         DissolvedResponseObject responseObject =
                 new DissolvedResponseObject(SEARCH_FOUND, createSearchResults());
 
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH)).thenReturn(responseObject);
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
         ResponseEntity responseEntity =
-                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, REQUEST_ID);
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(FOUND, responseEntity.getStatusCode());
@@ -109,7 +147,7 @@ class DissolvedSearchControllerTest {
                         .body("Invalid url parameter for search_type, please try 'alphabetical' or 'best-match'"));
 
         ResponseEntity responseEntity =
-                dissolvedSearchController.searchCompanies(COMPANY_NAME, "aaa", REQUEST_ID);
+                dissolvedSearchController.searchCompanies(COMPANY_NAME, "aaa", START_INDEX, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -44,6 +44,7 @@ class DissolvedSearchRequestsTest {
     private EnvironmentReader mockEnvironmentReader;
 
     private static final String ENV_READER_RESULT = "1";
+    private static final Integer START_INDEX = 0;
 
     @Test
     @DisplayName("Get best match response")
@@ -125,7 +126,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-            .getDissolved("orderedAlpha", "requestId", "searchType");
+            .getDissolved("orderedAlpha", "requestId", "searchType", START_INDEX);
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);
@@ -139,7 +140,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-                .getDissolved("companyName", "requestId", "searchType");
+                .getDissolved("companyName", "requestId", "searchType", START_INDEX);
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -50,6 +50,7 @@ class DissolvedSearchIndexServiceTest {
     private static final String KIND = "searchresults#dissolvedCompany";
     private static final String SEARCH_TYPE_BEST_MATCH = "best-match";
     private static final String SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH = "previous-name-dissolved";
+    private static final Integer START_INDEX = 0;
 
 
     @Test
@@ -89,9 +90,9 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search request returns successfully")
     void searchBestMatchDissolvedRequestSuccessful() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
                 .thenReturn(createSearchResults(true));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -100,10 +101,10 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search returns an error")
     void searchBestMatchDissolvedRequestReturnsError() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
                 .thenThrow(SearchException.class);
 
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -112,9 +113,9 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match dissolved search returns no results")
     void searchBestMatchDissolvedRequestReturnsNoResults() throws Exception {
-        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
                 .thenReturn(createSearchResults(false));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -124,9 +125,9 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX))
                 .thenReturn(createSearchResults(true));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -135,10 +136,10 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search returns an error")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsError() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX))
                 .thenThrow(SearchException.class);
 
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -147,9 +148,9 @@ class DissolvedSearchIndexServiceTest {
     @Test
     @DisplayName("Test best match for previous company names on a dissolved search returns no results")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
-        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
+        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX))
                 .thenReturn(createSearchResults(false));
-        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
+        DissolvedResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -75,6 +75,7 @@ class DissolvedSearchRequestServiceTest {
     private static final String PREVIOUS_NAME_KIND = "search#previous-name-dissolved";
     private static final String BEST_MATCH_KIND = "search#dissolved";
     private static final String DISSOLVED_ALPHABETICAL_KIND = "search#alphabetical-dissolved";
+    private static final Integer START_INDEX = 0;
 
 
     @Test
@@ -371,7 +372,7 @@ class DissolvedSearchRequestServiceTest {
         DissolvedCompany topHitCompany = createDissolvedCompany();
         DissolvedTopHit topHit = createDissolvedTopHit();
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID,SEARCH_TYPE_BEST_MATCH)).
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID,SEARCH_TYPE_BEST_MATCH, START_INDEX)).
             thenReturn(createSearchHits(true,true,true, true));
 
         when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
@@ -379,7 +380,7 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         DissolvedSearchResults dissolvedSearchResults =
-                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH);
+                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
         assertEquals(BEST_MATCH_KIND, dissolvedSearchResults.getKind());
@@ -389,11 +390,11 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test get best match search request throws exception")
     void testBestMatchThrowException() throws Exception{
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH))
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
             .thenThrow(IOException.class);
 
         assertThrows(SearchException.class, () ->
-            dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH));
+            dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX));
     }
 
     @Test
@@ -403,7 +404,7 @@ class DissolvedSearchRequestServiceTest {
         List<DissolvedPreviousName> results = createPreviousCompanyNames();
         PreviousNamesTopHit topHit = createPreviousNamesTopHit();
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH)).
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).
                 thenReturn(createSearchHits(true,true,true, true));
 
         when(mockElasticSearchResponseMapper.mapPreviousNames(any(SearchHits.class))).thenReturn(results);
@@ -411,7 +412,7 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapPreviousNamesTopHit(results)).thenReturn(topHit);
 
         DissolvedSearchResults dissolvedSearchResults =
-                dissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH);
+                dissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
         assertEquals(PREVIOUS_NAME_KIND, dissolvedSearchResults.getKind());
@@ -421,22 +422,22 @@ class DissolvedSearchRequestServiceTest {
     @DisplayName("Test get previous names best match search request throws exception")
     void testPreviousNamesBestMatchThrowException() throws Exception{
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX))
                 .thenThrow(IOException.class);
 
         assertThrows(SearchException.class, () ->
-                dissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH));
+                dissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX));
     }
 
     @Test
     @DisplayName("Test get best match previous names search request throws exception")
     void testBestMatchPreviousNamesThrowException() throws Exception{
 
-        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH))
+        when(mockDissolvedSearchRequests.getDissolved(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX))
                 .thenThrow(IOException.class);
 
         assertThrows(SearchException.class, () ->
-                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH));
+                dissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX));
     }
 
     @Test


### PR DESCRIPTION
Introduces a new optional query param called `start_index` which allows control of where you return in the returned results. Also adds the number of hits returned from the API for a given search term. This will allow for the number of pages to be calculated.

Resolves: BI-7515, BI-7516 
