### PR TITLE
Update dissolved best match and previous names queries to include company number

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -30,7 +30,7 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
 
         BoolQueryBuilder boolQueryBuilder =
                 QueryBuilders.boolQuery().should(QueryBuilders.matchQuery("previous_company_names.short_name.company_name_best_match", companySearchTerm))
-                        .should(QueryBuilders.matchQuery("_id", companySearchTerm));;
+                        .should(QueryBuilders.matchQuery("_id", companySearchTerm));
 
         return QueryBuilders.nestedQuery("previous_company_names", boolQueryBuilder, ScoreMode.Avg)
                 .innerHit(new InnerHitBuilder());

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -22,8 +22,8 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
         return QueryBuilders.matchPhrasePrefixQuery("company_name.startswith", corporateName);
     }
 
-    public QueryBuilder createBestMatchQuery(String companyName) {
-        return QueryBuilders.multiMatchQuery(companyName,"company_number", "short_name.company_name_best_match");
+    public QueryBuilder createBestMatchQuery(String companySearchTerm) {
+        return QueryBuilders.multiMatchQuery(companySearchTerm,"company_number", "short_name.company_name_best_match");
     }
 
     public QueryBuilder createPreviousNamesBestMatchQuery(String companySearchTerm) {

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -26,10 +26,11 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
         return QueryBuilders.multiMatchQuery(companyName,"company_number", "short_name.company_name_best_match");
     }
 
-    public QueryBuilder createPreviousNamesBestMatchQuery(String companyName) {
+    public QueryBuilder createPreviousNamesBestMatchQuery(String companySearchTerm) {
 
         BoolQueryBuilder boolQueryBuilder =
-                QueryBuilders.boolQuery().should(QueryBuilders.matchQuery("previous_company_names.short_name.company_name_best_match", companyName));
+                QueryBuilders.boolQuery().should(QueryBuilders.matchQuery("previous_company_names.short_name.company_name_best_match", companySearchTerm))
+                        .should(QueryBuilders.matchQuery("_id", companySearchTerm));;
 
         return QueryBuilders.nestedQuery("previous_company_names", boolQueryBuilder, ScoreMode.Avg)
                 .innerHit(new InnerHitBuilder());

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchQueries.java
@@ -23,7 +23,7 @@ public class DissolvedSearchQueries extends AbstractSearchQuery {
     }
 
     public QueryBuilder createBestMatchQuery(String companyName) {
-        return QueryBuilders.matchQuery("short_name.company_name_best_match", companyName);
+        return QueryBuilders.multiMatchQuery(companyName,"company_number", "short_name.company_name_best_match");
     }
 
     public QueryBuilder createPreviousNamesBestMatchQuery(String companyName) {


### PR DESCRIPTION
Enable searching by company number for best match and previous names while maintaining search by company name.

Resolves: BI-8013, BI-8023