### PR TITLE
add additional empty object checks to alpha and dissolved search services

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchIndexService.java
@@ -1,5 +1,17 @@
 package uk.gov.companieshouse.search.api.service.search.impl.alphabetical;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.exception.SearchException;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
+import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
+
+import java.util.Map;
+
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX_ALPHABETICAL;
@@ -9,19 +21,6 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SIZE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.createLoggingMap;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.logIfNotNull;
-
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import uk.gov.companieshouse.search.api.exception.SearchException;
-import uk.gov.companieshouse.search.api.model.SearchResults;
-import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
-import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
-import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
-import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
 
 @Service
 public class AlphabeticalSearchIndexService implements SearchIndexService {
@@ -55,7 +54,7 @@ public class AlphabeticalSearchIndexService implements SearchIndexService {
             return new ResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
-        if(searchResults.getItems() != null) {
+        if(searchResults.getItems() != null && !searchResults.getItems().isEmpty()) {
             getLogger().info("Search successful", logMap);
             return new ResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -1,5 +1,16 @@
 package uk.gov.companieshouse.search.api.service.search.impl.dissolved;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.exception.SearchException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.esdatamodel.DissolvedCompany;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+
+import java.util.Map;
+
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_ALPHABETICAL;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
@@ -11,18 +22,6 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SIZE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.START_INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.logIfNotNull;
-
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import uk.gov.companieshouse.search.api.exception.SearchException;
-import uk.gov.companieshouse.search.api.logging.LoggingUtils;
-import uk.gov.companieshouse.search.api.model.SearchResults;
-import uk.gov.companieshouse.search.api.model.esdatamodel.DissolvedCompany;
-import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 
 @Service
 public class DissolvedSearchIndexService {
@@ -55,7 +54,7 @@ public class DissolvedSearchIndexService {
             return new ResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
-        if (searchResults.getItems() != null) {
+        if (searchResults.getItems() != null && !searchResults.getItems().isEmpty()) {
             getLogger().info("successful alphabetical search for dissolved company", logMap);
             return new ResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);
         }
@@ -87,7 +86,7 @@ public class DissolvedSearchIndexService {
             return new ResponseObject(ResponseStatus.SEARCH_ERROR, null);
         }
 
-        if (searchResults.getItems() != null) {
+        if (searchResults.getItems() != null && !searchResults.getItems().isEmpty()) {
             getLogger().info("successful best match search for " + searchType + " dissolved company",
                     logMap);
             return new ResponseObject(ResponseStatus.SEARCH_FOUND, searchResults);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
@@ -1,12 +1,5 @@
 package uk.gov.companieshouse.search.api.service.search.alphabetical;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,17 +8,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.TopHit;
-import uk.gov.companieshouse.search.api.model.esdatamodel.Links;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
+import uk.gov.companieshouse.search.api.model.esdatamodel.Links;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -40,7 +39,7 @@ class AlphabeticalSearchIndexServiceTest {
     private TopHit TOP_HIT;
     private static final String REQUEST_ID = "requestId";
     private static final String CORPORATE_NAME = "corporateName";
-    
+
     @BeforeAll
     void setUp() {
         TOP_HIT = new TopHit();
@@ -51,7 +50,7 @@ class AlphabeticalSearchIndexServiceTest {
     @DisplayName("Test search request returns successfully")
     void searchRequestSuccessful() throws Exception {
         when(mockSearchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID))
-            .thenReturn(createSearchResults(true));
+            .thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.search(CORPORATE_NAME, null, null, null, REQUEST_ID);
 
         assertNotNull(responseObject);
@@ -74,20 +73,37 @@ class AlphabeticalSearchIndexServiceTest {
     @DisplayName("Test search returns no results")
     void searchRequestReturnsNoResults() throws Exception {
         when(mockSearchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID))
-            .thenReturn(createSearchResults(false));
+            .thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.search(CORPORATE_NAME, null, null, null, REQUEST_ID);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
     }
 
-    private SearchResults<Company> createSearchResults(boolean isResultsPopulated) {
+    @Test
+    @DisplayName("Test search returns empty results")
+    void emptySearchRequestReturnsNoResults() throws Exception {
+        when(mockSearchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID))
+            .thenReturn(createSearchResults(false, true));
+        ResponseObject responseObject = searchIndexService.search(CORPORATE_NAME, null, null, null, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
+    }
+
+    private SearchResults<Company> createSearchResults(boolean isResultsPopulated, boolean isItemsEmpty) {
         SearchResults<Company> searchResults = new SearchResults<>();
         searchResults.setKind("alphabetical");
-        searchResults.setTopHit(TOP_HIT);
 
-        if (isResultsPopulated) {
-            searchResults.setItems(createResults());
+        if (!isItemsEmpty) {
+            searchResults.setTopHit(TOP_HIT);
+
+            if (isResultsPopulated) {
+                searchResults.setItems(createResults());
+            }
+        } else {
+            searchResults.setTopHit(null);
+            searchResults.setItems(null);
         }
         return searchResults;
     }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -59,7 +59,7 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test dissolved alphabetical search request returns successfully")
     void searchDissolvedAlphabeticalRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getSearchResults(COMPANY_NAME, SEARCH_BEFORE, SEARCH_AFTER, SIZE,
-                REQUEST_ID)).thenReturn(createSearchResults(true));
+                REQUEST_ID)).thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchAlphabetical(COMPANY_NAME, SEARCH_BEFORE,
                 SEARCH_AFTER, SIZE, REQUEST_ID);
 
@@ -84,9 +84,21 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test dissolved alphabetical search returns no results")
     void searchDissolvedAlphabeticalRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID))
-                .thenReturn(createSearchResults(false));
+                .thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchAlphabetical(COMPANY_NAME, SEARCH_BEFORE,
                 SEARCH_AFTER, SIZE, REQUEST_ID);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
+    }
+
+    @Test
+    @DisplayName("Test dissolved alphabetical search returns no results when response object is empty")
+    void emptySearchDissolvedAlphabeticalRequestReturnsNoResults() throws Exception {
+        when(mockDissolvedSearchRequestService.getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID))
+            .thenReturn(createSearchResults(false, true));
+        ResponseObject responseObject = searchIndexService.searchAlphabetical(COMPANY_NAME, SEARCH_BEFORE,
+            SEARCH_AFTER, SIZE, REQUEST_ID);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -96,7 +108,7 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match dissolved search request returns successfully")
     void searchBestMatchDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true));
+                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
                 SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
@@ -121,7 +133,7 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match dissolved search returns no results")
     void searchBestMatchDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false));
+                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
                 SEARCH_TYPE_BEST_MATCH, START_INDEX);
 
@@ -134,7 +146,7 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true));
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
                 SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
@@ -159,7 +171,7 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search returns no results")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false));
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
                 SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
 
@@ -167,7 +179,19 @@ class DissolvedSearchIndexServiceTest {
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
     }
 
-    private SearchResults createSearchResults(boolean isResultsPopulated) {
+    @Test
+    @DisplayName("Test best match for previous company names on a dissolved search returns no results when result is empty")
+    void emptySearchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
+        when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
+            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, true));
+        ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
+            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
+
+        assertNotNull(responseObject);
+        assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
+    }
+
+    private SearchResults createSearchResults(boolean isResultsPopulated, boolean isItemsEmpty) {
         SearchResults searchResults = new SearchResults();
         TopHit topHit = new TopHit();
         topHit.setCompanyName("companyName");
@@ -176,7 +200,11 @@ class DissolvedSearchIndexServiceTest {
         searchResults.setEtag("etag");
         searchResults.setKind(KIND);
         if (isResultsPopulated) {
-            searchResults.setItems(createItems());
+            if(!isItemsEmpty) {
+                searchResults.setItems(createItems());
+            } else {
+                searchResults.setItems(new ArrayList<DissolvedCompany>());
+            }
         }
         return searchResults;
     }


### PR DESCRIPTION
Check if the search results response object is empty, if so return a 404 no results found status for alphabetical and dissolved searches.

Resolves: BI-7055 & BI-7056