### PR TITLE
Make results size consistent to size parameter

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -45,7 +45,8 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
     private static final int FALLBACK_QUERY_LIMIT = 25;
 
-    private Integer sizeAbove, sizeBelow;
+    private Integer sizeAbove;
+    private Integer sizeBelow;
 
     /**
      * {@inheritDoc}
@@ -102,18 +103,8 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
                 topHitCompany.setKind(company.getKind());
 
                 if ((searchBefore == null && searchAfter == null) || (searchBefore != null && searchAfter != null)) {
-                    checkSize(size);
-                    logMap.put(ORDERED_ALPHAKEY_WITH_ID, orderedAlphakeyWithId);
-                    getLogger().info("Default alphabetical search before and after tophit", logMap);
-                    if (sizeAbove > 0) {
-                        results = populateAboveResults(requestId, topHitCompany.getCompanyName(), orderedAlphakeyWithId,
-                                sizeAbove);
-                    }
-                    results.add(company);
-                    if (sizeBelow > 0) {
-                        results.addAll(populateBelowResults(requestId, topHitCompany.getCompanyName(),
-                                orderedAlphakeyWithId, sizeBelow));
-                    }
+                    results = prepareSearchResultsWithTopHit(size, requestId, logMap, topHitCompany, results,
+                            orderedAlphakeyWithId, company);
                 } else if (searchAfter != null) {
                     getLogger().info("Searching alphabetical companies after", logMap);
                     results.addAll(populateBelowResults(requestId, topHitCompany.getCompanyName(), searchAfter, size));
@@ -127,6 +118,24 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
             throw new SearchException("error occurred reading data for highest match from " + "searchHits", e);
         }
         return new SearchResults<>("", topHitCompany, results, kind);
+    }
+
+    private List<Company> prepareSearchResultsWithTopHit(Integer size, String requestId, Map<String, Object> logMap,
+            TopHit topHitCompany, List<Company> results, String orderedAlphakeyWithId, Company company)
+            throws IOException {
+        checkSize(size);
+        logMap.put(ORDERED_ALPHAKEY_WITH_ID, orderedAlphakeyWithId);
+        getLogger().info("Default alphabetical search before and after tophit", logMap);
+        if (sizeAbove > 0) {
+            results = populateAboveResults(requestId, topHitCompany.getCompanyName(), orderedAlphakeyWithId,
+                    sizeAbove);
+        }
+        results.add(company);
+        if (sizeBelow > 0) {
+            results.addAll(populateBelowResults(requestId, topHitCompany.getCompanyName(),
+                    orderedAlphakeyWithId, sizeBelow));
+        }
+        return results;
     }
 
     public SearchHits peelbackSearchRequest(SearchHits hits, String orderedAlphakey, String requestId)

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -55,7 +55,8 @@ public class DissolvedSearchRequestService {
     private static final String RESULT_FOUND = "A result has been found";
     private static final String SEARCH_HITS = "searchHits";
     
-    private Integer sizeAbove, sizeBelow;
+    private Integer sizeAbove;
+    private Integer sizeBelow;
 
     public SearchResults<DissolvedCompany> getSearchResults(String companyName, String searchBefore, String searchAfter,
             Integer size, String requestId) throws SearchException {
@@ -100,17 +101,8 @@ public class DissolvedSearchRequestService {
                 topHit = elasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany);
 
                 if ((searchBefore == null && searchAfter == null) || (searchBefore != null && searchAfter != null)) {
-                    checkSize(size);
-                    logMap.put(ORDERED_ALPHAKEY_WITH_ID, orderedAlphaKeyWithId);
-                    getLogger().info("Default dissolved search before and after tophit", logMap);
-                    if (sizeAbove > 0) {
-                        results = populateAboveResults(requestId, topHit.getCompanyName(), orderedAlphaKeyWithId, sizeAbove);
-                    }
-                    results.add(topHitCompany);
-                    if (sizeBelow > 0) {
-                        results.addAll(
-                                populateBelowResults(requestId, topHit.getCompanyName(), orderedAlphaKeyWithId, sizeBelow));
-                    }
+                    results = prepareSearchResultsWithTopHit(size, requestId, logMap, results, topHit,
+                            orderedAlphaKeyWithId, topHitCompany);
                 } else if (searchAfter != null) {
                     getLogger().info("Searching dissolved companies after", logMap);
                     results.addAll(populateBelowResults(requestId, topHit.getCompanyName(), searchAfter, size));
@@ -125,6 +117,23 @@ public class DissolvedSearchRequestService {
         }
 
         return new SearchResults<>(etag, topHit, results, kind);
+    }
+
+    private List<DissolvedCompany> prepareSearchResultsWithTopHit(Integer size, String requestId,
+            Map<String, Object> logMap, List<DissolvedCompany> results, DissolvedTopHit topHit,
+            String orderedAlphaKeyWithId, DissolvedCompany topHitCompany) throws IOException {
+        checkSize(size);
+        logMap.put(ORDERED_ALPHAKEY_WITH_ID, orderedAlphaKeyWithId);
+        getLogger().info("Default dissolved search before and after tophit", logMap);
+        if (sizeAbove > 0) {
+            results = populateAboveResults(requestId, topHit.getCompanyName(), orderedAlphaKeyWithId, sizeAbove);
+        }
+        results.add(topHitCompany);
+        if (sizeBelow > 0) {
+            results.addAll(
+                    populateBelowResults(requestId, topHit.getCompanyName(), orderedAlphaKeyWithId, sizeBelow));
+        }
+        return results;
     }
 
     public SearchResults<DissolvedCompany> getBestMatchSearchResults(String companyName,

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -5,6 +5,7 @@ import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -61,17 +62,34 @@ class AlphabeticalSearchRequestServiceTest {
                 .thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                10)).thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                9)).thenReturn(createSearchHits());
 
         SearchResults<Company> searchResults =
-            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID);
+            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 20, REQUEST_ID);
 
         assertNotNull(searchResults);
         assertEquals( TOP_HIT, searchResults.getTopHit().getCompanyName());
         assertEquals(3, searchResults.getItems().size());
+    }
+    
+    @Test
+    @DisplayName("Test search request returns results successfully with best match query and a size of 1")
+    void testBestMatchSuccessfulWithSizeOne() throws Exception {
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(CORPORATE_NAME)).thenReturn(createAlphaKeyResponse());
+
+        when(mockAlphabeticalSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+                .thenReturn(createSearchHits());
+
+        SearchResults<Company> searchResults =
+            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 1, REQUEST_ID);
+
+        assertNotNull(searchResults);
+        assertEquals( TOP_HIT, searchResults.getTopHit().getCompanyName());
+        assertEquals(1, searchResults.getItems().size());
     }
 
     @Test
@@ -87,13 +105,13 @@ class AlphabeticalSearchRequestServiceTest {
                 .thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                10)).thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                9)).thenReturn(createSearchHits());
 
         SearchResults<Company> searchResults =
-            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID);
+            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 20, REQUEST_ID);
 
         assertNotNull(searchResults);
         assertEquals(TOP_HIT, searchResults.getTopHit().getCompanyName());
@@ -116,13 +134,13 @@ class AlphabeticalSearchRequestServiceTest {
                 .thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                5)).thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                5)).thenReturn(createSearchHits());
 
         SearchResults<Company> searchResults =
-            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, null, REQUEST_ID);
+            searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 11, REQUEST_ID);
 
         assertNotNull(searchResults);
         assertEquals(TOP_HIT, searchResults.getTopHit().getCompanyName());
@@ -205,13 +223,13 @@ class AlphabeticalSearchRequestServiceTest {
                 .thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                10)).thenReturn(createSearchHits());
 
         when(mockAlphabeticalSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, TOP_HIT,
-                null)).thenReturn(createSearchHits());
+                9)).thenReturn(createSearchHits());
 
         SearchResults<Company> searchResults = searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME,
-                SEARCH_BEFORE_VALUE, SEARCH_AFTER_VALUE, null, REQUEST_ID);
+                SEARCH_BEFORE_VALUE, SEARCH_AFTER_VALUE, 20, REQUEST_ID);
 
         assertNotNull(searchResults);
         assertEquals(TOP_HIT, searchResults.getTopHit().getCompanyName());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -74,7 +74,7 @@ class DissolvedSearchRequestServiceTest {
     private static final String PREVIOUS_NAME_KIND = "search#previous-name-dissolved";
     private static final String BEST_MATCH_KIND = "search#dissolved";
     private static final String DISSOLVED_ALPHABETICAL_KIND = "search#alphabetical-dissolved";
-    private static final Integer SIZE = null;
+    private static final Integer SIZE = 20;
     private static final Integer START_INDEX = 0;
     private static final String SEARCH_BEFORE_VALUE = "search_before:1234";
     private static final String SEARCH_AFTER_VALUE = "search_after:1234";
@@ -96,17 +96,42 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
         assertEquals(3, dissolvedSearchResults.getItems().size());
+        assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
+    }
+    
+    @Test
+    @DisplayName("Test dissolved alphabetical search request returns results successfully with best match query and a size of one")
+    void testDissolvedAlphabeticalBestMatchSuccessfulWithSizeOne() throws Exception {
+
+        SearchHits searchHits = createSearchHits(true, true, true, true);
+        DissolvedCompany topHitCompany = createDissolvedCompany();
+        DissolvedTopHit topHit = createDissolvedTopHit();
+
+        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME)).thenReturn(createAlphaKeyResponse());
+
+        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID)).thenReturn(searchHits);
+
+        when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
+
+        when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
+
+        SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
+                .getSearchResults(COMPANY_NAME, null, null, 1, REQUEST_ID);
+
+        assertNotNull(dissolvedSearchResults);
+        assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
+        assertEquals(1, dissolvedSearchResults.getItems().size());
         assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
     }
 
@@ -127,13 +152,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                1)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 1)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, 3, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -161,13 +186,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertNotNull(dissolvedSearchResults.getEtag());
@@ -200,13 +225,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -238,13 +263,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -276,13 +301,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -314,13 +339,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -449,7 +474,7 @@ class DissolvedSearchRequestServiceTest {
                 .thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, SEARCH_BEFORE_VALUE, null, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, SEARCH_BEFORE_VALUE, null, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -477,7 +502,7 @@ class DissolvedSearchRequestServiceTest {
                 SIZE)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, SEARCH_AFTER_VALUE, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, null, SEARCH_AFTER_VALUE, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
@@ -502,13 +527,13 @@ class DissolvedSearchRequestServiceTest {
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
         when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                SIZE)).thenReturn(searchHits);
+                10)).thenReturn(searchHits);
 
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, SIZE)).thenReturn(searchHits);
+                COMPANY_NAME, 9)).thenReturn(searchHits);
 
         SearchResults<DissolvedCompany> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, SEARCH_BEFORE_VALUE, SEARCH_AFTER_VALUE, null, REQUEST_ID);
+                .getSearchResults(COMPANY_NAME, SEARCH_BEFORE_VALUE, SEARCH_AFTER_VALUE, SIZE, REQUEST_ID);
 
         assertNotNull(dissolvedSearchResults);
         assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());


### PR DESCRIPTION
Amendments made to make the size of the results consistent to the size parameter when returning a search with a top hit company

Resolves BI-8216