### PR TITLE
Add size param functionality for dissolved best match and previous company name searches

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -54,14 +54,15 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
     public SearchHits getDissolved(String companyName,
                                    String requestId,
                                    String searchType,
-                                   Integer startIndex) throws IOException {
+                                   Integer startIndex,
+                                   Integer size) throws IOException {
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
         logMap.put(LoggingUtils.COMPANY_NAME, companyName);
         LoggingUtils.getLogger().info("Searching for best dissolved company name " + searchType + " match", logMap);
 
         SearchRequest searchRequest = getBaseSearchRequest(requestId);
 
-        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder(startIndex);
+        SearchSourceBuilder sourceBuilder = getBaseSourceBuilder(startIndex, size);
         if (searchType.equals(BEST_MATCH_SEARCH_TYPE)){
             sourceBuilder.query(searchQueries.createBestMatchQuery(companyName));
         }
@@ -86,9 +87,13 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
         return searchRequest;
     }
 
-    private SearchSourceBuilder getBaseSourceBuilder(Integer startIndex) {
+    private SearchSourceBuilder getBaseSourceBuilder(Integer startIndex, Integer size) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-        sourceBuilder.size(Integer.parseInt(environmentReader.getMandatoryString(getResultsSize())));
+        if(size != null) {
+            sourceBuilder.size(size.intValue());
+        } else {
+            sourceBuilder.size(Integer.parseInt(environmentReader.getMandatoryString(getResultsSize())));
+        }
         sourceBuilder.from(startIndex);
 
         return sourceBuilder;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -1,16 +1,5 @@
 package uk.gov.companieshouse.search.api.service.search.impl.dissolved;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.search.api.exception.SearchException;
-import uk.gov.companieshouse.search.api.logging.LoggingUtils;
-import uk.gov.companieshouse.search.api.model.SearchResults;
-import uk.gov.companieshouse.search.api.model.esdatamodel.DissolvedCompany;
-import uk.gov.companieshouse.search.api.model.response.ResponseObject;
-import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
-
-import java.util.Map;
-
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_ALPHABETICAL;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
@@ -22,6 +11,16 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SIZE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.START_INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.logIfNotNull;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.exception.SearchException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.esdatamodel.DissolvedCompany;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 
 @Service
 public class DissolvedSearchIndexService {
@@ -64,7 +63,7 @@ public class DissolvedSearchIndexService {
     }
 
     public ResponseObject searchBestMatch(String companyName, String requestId, String searchType,
-            Integer startIndex) {
+            Integer startIndex, Integer size) {
         Map<String, Object> logMap = getLogMap(companyName, requestId, searchType);
         logIfNotNull(logMap, START_INDEX, startIndex);
         logMap.remove(MESSAGE);
@@ -74,11 +73,11 @@ public class DissolvedSearchIndexService {
             if (searchType.equals(BEST_MATCH_SEARCH_TYPE)) {
                 getLogger().info("Searching using Best Match", logMap);
                 searchResults = dissolvedSearchRequestService.getBestMatchSearchResults(companyName, requestId,
-                        searchType, startIndex);
+                        searchType, startIndex, size);
             } else {
                 getLogger().info("Searching previous names", logMap);
                 searchResults = dissolvedSearchRequestService.getPreviousNamesResults(companyName, requestId,
-                        searchType, startIndex);
+                        searchType, startIndex, size);
             }
         } catch (SearchException e) {
             getLogger()

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -139,7 +139,8 @@ public class DissolvedSearchRequestService {
     public SearchResults<DissolvedCompany> getBestMatchSearchResults(String companyName,
                                                             String requestId,
                                                             String searchType,
-                                                            Integer startIndex) throws SearchException {
+                                                            Integer startIndex,
+                                                            Integer size) throws SearchException {
         Map<String, Object> logMap = getLogMap(requestId, companyName);
         logMap.put(START_INDEX, startIndex);
         logMap.put(SEARCH_TYPE, searchType);
@@ -152,7 +153,7 @@ public class DissolvedSearchRequestService {
         long numberOfHits;
 
         try {
-            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
+            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex, size);
             numberOfHits = hits.getTotalHits().value;
 
             if (hits.getTotalHits().value > 0) {
@@ -179,7 +180,8 @@ public class DissolvedSearchRequestService {
     public SearchResults<DissolvedPreviousName> getPreviousNamesResults(String companyName,
                                                                                  String requestId,
                                                                                  String searchType,
-                                                                                 Integer startIndex) throws SearchException {
+                                                                                 Integer startIndex,
+                                                                                 Integer size) throws SearchException {
         Map<String, Object> logMap = getLogMap(requestId, companyName);
         logMap.put(START_INDEX, startIndex);
         logMap.put(SEARCH_TYPE, searchType);
@@ -192,7 +194,7 @@ public class DissolvedSearchRequestService {
         long numberOfHits;
 
         try {
-            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex);
+            SearchHits hits  = dissolvedSearchRequests.getDissolved(companyName, requestId, searchType, startIndex, size);
             numberOfHits = hits.getTotalHits().value;
 
             if (hits.getTotalHits().value > 0) {

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/search/DissolvedSearchControllerTest.java
@@ -89,10 +89,7 @@ class DissolvedSearchControllerTest {
 
         ResponseObject responseObject = new ResponseObject(SEARCH_FOUND, createSearchResults());
 
-        doReturn(50).when(mockEnvironmentReader).getMandatoryInteger(MAX_SIZE_PARAM);
-        doReturn(40).when(mockEnvironmentReader).getMandatoryInteger(DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX);
-
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE))
                 .thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
@@ -110,10 +107,7 @@ class DissolvedSearchControllerTest {
 
         ResponseObject responseObject = new ResponseObject(SEARCH_FOUND, createSearchResults());
 
-        doReturn(50).when(mockEnvironmentReader).getMandatoryInteger(MAX_SIZE_PARAM);
-        doReturn(40).when(mockEnvironmentReader).getMandatoryInteger(DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX);
-
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE))
                 .thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
@@ -131,10 +125,7 @@ class DissolvedSearchControllerTest {
 
         ResponseObject responseObject = new ResponseObject(SEARCH_FOUND, createSearchResults());
 
-        doReturn(50).when(mockEnvironmentReader).getMandatoryInteger(MAX_SIZE_PARAM);
-        doReturn(40).when(mockEnvironmentReader).getMandatoryInteger(DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX);
-
-        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX))
+        when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE))
                 .thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
@@ -152,11 +143,8 @@ class DissolvedSearchControllerTest {
 
         ResponseObject responseObject = new ResponseObject(SEARCH_FOUND, createSearchResults());
 
-        doReturn(50).when(mockEnvironmentReader).getMandatoryInteger(MAX_SIZE_PARAM);
-        doReturn(40).when(mockEnvironmentReader).getMandatoryInteger(DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX);
-
         when(mockSearchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID, SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH,
-                START_INDEX)).thenReturn(responseObject);
+                START_INDEX, SIZE)).thenReturn(responseObject);
         when(mockApiToResponseMapper.mapDissolved(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
@@ -218,6 +206,7 @@ class DissolvedSearchControllerTest {
     @DisplayName("Test Alphabetical dissolved search invalid as size parameter is less than 0")
     void testNegativeSizeParameter() {
 
+
         ResponseEntity responseEntity = getResponseEntity(-6);
 
         assertEquals(SIZE_PARAMETER_ERROR, responseObjectCaptor.getValue().getStatus());
@@ -264,6 +253,6 @@ class DissolvedSearchControllerTest {
         when(mockApiToResponseMapper.mapDissolved(responseObjectCaptor.capture()))
             .thenReturn(ResponseEntity.status(UNPROCESSABLE_ENTITY).build());
 
-        return dissolvedSearchController.searchCompanies("test name", null, null, null, size, null, REQUEST_ID);
+        return dissolvedSearchController.searchCompanies("test name", "alphabetical", null, null, size, null, REQUEST_ID);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -1,5 +1,11 @@
 package uk.gov.companieshouse.search.api.elasticsearch;
 
+import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchRequest;
@@ -19,13 +25,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.service.rest.impl.DissolvedSearchRestClientService;
-
-import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -127,7 +126,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-            .getDissolved("orderedAlpha", "requestId", "searchType", START_INDEX);
+            .getDissolved("orderedAlpha", "requestId", "searchType", START_INDEX, SIZE);
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);
@@ -141,7 +140,7 @@ class DissolvedSearchRequestsTest {
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
 
         SearchHits searchHits = dissolvedSearchRequests
-                .getDissolved("companyName", "requestId", "searchType", START_INDEX);
+                .getDissolved("companyName", "requestId", "searchType", START_INDEX, SIZE);
 
         assertNotNull(searchHits);
         assertEquals(1, searchHits.getTotalHits().value);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -1,5 +1,12 @@
 package uk.gov.companieshouse.search.api.service.search.dissolved;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -17,14 +24,6 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchRequestService;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -53,7 +52,7 @@ class DissolvedSearchIndexServiceTest {
     private static final Integer START_INDEX = 0;
     private static final String SEARCH_BEFORE = null;
     private static final String SEARCH_AFTER = null;
-    private static final Integer SIZE = null;
+    private static final Integer SIZE = 20;
 
     @Test
     @DisplayName("Test dissolved alphabetical search request returns successfully")
@@ -86,7 +85,7 @@ class DissolvedSearchIndexServiceTest {
         when(mockDissolvedSearchRequestService.getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID))
                 .thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchAlphabetical(COMPANY_NAME, SEARCH_BEFORE,
-                SEARCH_AFTER, SIZE, REQUEST_ID);
+                SEARCH_AFTER, null, REQUEST_ID);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -98,7 +97,7 @@ class DissolvedSearchIndexServiceTest {
         when(mockDissolvedSearchRequestService.getSearchResults(COMPANY_NAME, null, null, null, REQUEST_ID))
             .thenReturn(createSearchResults(false, true));
         ResponseObject responseObject = searchIndexService.searchAlphabetical(COMPANY_NAME, SEARCH_BEFORE,
-            SEARCH_AFTER, SIZE, REQUEST_ID);
+            SEARCH_AFTER, null, REQUEST_ID);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -108,9 +107,9 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match dissolved search request returns successfully")
     void searchBestMatchDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true, false));
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE)).thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -120,10 +119,10 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match dissolved search returns an error")
     void searchBestMatchDissolvedRequestReturnsError() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenThrow(SearchException.class);
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE)).thenThrow(SearchException.class);
 
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -133,9 +132,9 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match dissolved search returns no results")
     void searchBestMatchDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getBestMatchSearchResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, false));
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE)).thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -146,9 +145,9 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search request returns successfully")
     void searchBestMatchPreviousNamesDissolvedRequestSuccessful() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(true, false));
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE)).thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_FOUND, responseObject.getStatus());
@@ -158,10 +157,10 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search returns an error")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsError() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenThrow(SearchException.class);
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE)).thenThrow(SearchException.class);
 
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_ERROR, responseObject.getStatus());
@@ -171,9 +170,9 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search returns no results")
     void searchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, false));
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE)).thenReturn(createSearchResults(false, false));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
+                SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());
@@ -183,9 +182,9 @@ class DissolvedSearchIndexServiceTest {
     @DisplayName("Test best match for previous company names on a dissolved search returns no results when result is empty")
     void emptySearchBestMatchPreviousNamesDissolvedRequestReturnsNoResults() throws Exception {
         when(mockDissolvedSearchRequestService.getPreviousNamesResults(COMPANY_NAME, REQUEST_ID,
-            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX)).thenReturn(createSearchResults(false, true));
+            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE)).thenReturn(createSearchResults(false, true));
         ResponseObject responseObject = searchIndexService.searchBestMatch(COMPANY_NAME, REQUEST_ID,
-            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX);
+            SEARCH_TYPE_PREVIOUS_NAME_BEST_MATCH, START_INDEX, SIZE);
 
         assertNotNull(responseObject);
         assertEquals(ResponseStatus.SEARCH_NOT_FOUND, responseObject.getStatus());


### PR DESCRIPTION
Allows an api user to specify the number of results to be returned by providing a size parameter to a dissolved best-match or previous-name-dissolved search request

Resolves: BI-8226 & BI-8227