### PR TITLE
add logic to return size or less than size for previous name search

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -190,6 +190,7 @@ public class DissolvedSearchRequestService {
         String etag = GenerateEtagUtil.generateEtag();
         PreviousNamesTopHit topHit = new PreviousNamesTopHit();
         List<DissolvedPreviousName> results = new ArrayList<>();
+        List<DissolvedPreviousName> resizedResults = new ArrayList<>();
         String kind = "search#previous-name-dissolved";
         long numberOfHits;
 
@@ -203,6 +204,8 @@ public class DissolvedSearchRequestService {
                 results = elasticSearchResponseMapper.mapPreviousNames(hits);
                 topHit = elasticSearchResponseMapper.mapPreviousNamesTopHit(results);
 
+                int finalSize = results.size() < size ? results.size() : size;
+                resizedResults = results.subList(0, finalSize);
             }
         } catch (IOException e) {
             getLogger().error("failed to get previous names for dissolved company", logMap);
@@ -210,7 +213,7 @@ public class DissolvedSearchRequestService {
         }
 
         SearchResults<DissolvedPreviousName> dissolvedSearchResults =
-                new SearchResults<>(etag, topHit, results, kind);
+                new SearchResults<>(etag, topHit, resizedResults, kind);
         dissolvedSearchResults.setHits(numberOfHits);
 
         return dissolvedSearchResults;


### PR DESCRIPTION
Return the requested size of a dissolved previous name search or return what is available if the data is less than the size provided.

Resolves: BI-8227