### PR TITLE
Make etag optional in response

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/model/SearchResults.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/SearchResults.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SearchResults<T> {
 
     @JsonProperty("etag")


### PR DESCRIPTION
Change to not include empty fields rather than null for search results model as it was previously returning the etag field as it was an empty string.

Resolves: BI-6781