### PR TITLE
Allow multiple sic codes to be searched against

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/EnhancedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/EnhancedSearchController.java
@@ -10,6 +10,8 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SIC_CODES;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.logIfNotNull;
 
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,8 +29,6 @@ import uk.gov.companieshouse.search.api.model.EnhancedSearchQueryParams;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.enhanced.EnhancedSearchIndexService;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/enhanced-search", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -56,7 +56,7 @@ public class EnhancedSearchController {
                                          @RequestParam(name = LOCATION_QUERY_PARAM, required = false) String location,
                                          @RequestParam(name = INCORPORATED_FROM_QUERY_PARAMETER, required = false) String incorporatedFrom,
                                          @RequestParam(name = INCORPORATED_TO_QUERY_PARAMETER, required = false) String incorporatedTo,
-                                         @RequestParam(name = SIC_CODE_QUERY_PARAMETER, required = false) String sicCodes,
+                                         @RequestParam(name = SIC_CODE_QUERY_PARAMETER, required = false) List<String> sicCodes,
                                          @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
 
         Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/EnhancedSearchQueries.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/EnhancedSearchQueries.java
@@ -36,7 +36,7 @@ public class EnhancedSearchQueries {
 
         if (queryParams.getSicCodes() != null) {
 
-            queryBuilder = QueryBuilders.termQuery("current_company.sic_codes",
+            queryBuilder = QueryBuilders.termsQuery("current_company.sic_codes",
                     queryParams.getSicCodes());
 
             boolQueryBuilder.filter(queryBuilder);

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/EnhancedQueryParamMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/EnhancedQueryParamMapper.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.search.api.mapper;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.search.api.exception.DateFormatException;
 import uk.gov.companieshouse.search.api.model.EnhancedSearchQueryParams;
-
-import java.time.LocalDate;
 
 @Component
 public class EnhancedQueryParamMapper {
@@ -13,7 +13,7 @@ public class EnhancedQueryParamMapper {
                                                                  String location,
                                                                  String incorporatedFrom,
                                                                  String incorporatedTo,
-                                                                 String sicCodes) throws DateFormatException {
+                                                                 List<String> sicCodes) throws DateFormatException {
 
         EnhancedSearchQueryParams enhancedSearchQueryParams = new EnhancedSearchQueryParams();
         enhancedSearchQueryParams.setCompanyName(companyName);

--- a/src/main/java/uk/gov/companieshouse/search/api/model/EnhancedSearchQueryParams.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/EnhancedSearchQueryParams.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.search.api.model;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class EnhancedSearchQueryParams {
 
@@ -12,7 +13,7 @@ public class EnhancedSearchQueryParams {
 
     private LocalDate incorporatedTo;
 
-    private String sicCodes;
+    private List<String> sicCodes;
 
     public String getCompanyName() {
         return companyName;
@@ -46,11 +47,11 @@ public class EnhancedSearchQueryParams {
         this.incorporatedTo = incorporatedTo;
     }
 
-    public String getSicCodes() {
+    public List<String> getSicCodes() {
         return sicCodes;
     }
 
-    public void setSicCodes(String sicCodes) {
+    public void setSicCodes(List<String> sicCodes) {
         this.sicCodes = sicCodes;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/EnhancedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/EnhancedSearchControllerTest.java
@@ -64,16 +64,16 @@ class EnhancedSearchControllerTest {
 
         EnhancedSearchQueryParams enhancedSearchQueryParams = new EnhancedSearchQueryParams();
         enhancedSearchQueryParams.setCompanyName(COMPANY_NAME);
-        enhancedSearchQueryParams.setSicCodes(SIC_CODES);
+        enhancedSearchQueryParams.setSicCodes(SIC_CODES_LIST);
 
-        when(mockQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES))
+        when(mockQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES_LIST))
                 .thenReturn(enhancedSearchQueryParams);
         when(mockSearchIndexService.searchEnhanced(any(), anyString())).thenReturn(responseObject);
         when(mockApiToResponseMapper.map(responseObject))
                 .thenReturn(ResponseEntity.status(FOUND).body(responseObject.getData()));
 
         ResponseEntity<?> responseEntity =
-                enhancedSearchController.search(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES, REQUEST_ID);
+                enhancedSearchController.search(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES_LIST, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(FOUND, responseEntity.getStatusCode());
@@ -89,13 +89,13 @@ class EnhancedSearchControllerTest {
         EnhancedSearchQueryParams enhancedSearchQueryParams = new EnhancedSearchQueryParams();
         enhancedSearchQueryParams.setCompanyName(COMPANY_NAME);
 
-        when(mockQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES))
+        when(mockQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES_LIST))
                 .thenThrow(DateFormatException.class);
         when(mockApiToResponseMapper.map(any()))
                 .thenReturn(ResponseEntity.status(BAD_REQUEST).body("Date format exception"));
 
         ResponseEntity<?> responseEntity =
-                enhancedSearchController.search(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES, REQUEST_ID);
+                enhancedSearchController.search(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES_LIST, REQUEST_ID);
 
         assertNotNull(responseEntity);
         assertEquals(BAD_REQUEST, responseEntity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/EnhancedSearchQueriesTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/EnhancedSearchQueriesTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +22,7 @@ class EnhancedSearchQueriesTest {
     private static final LocalDate INCORPORATED_FROM = LocalDate.of(2000, 1, 1);
     private static final LocalDate INCORPORATED_TO = LocalDate.of(2002, 2, 2);
     private static final String SIC_CODES = "99960";
+    private static final List<String> SIC_CODES_LIST = Arrays.asList(SIC_CODES);
     private static final String COMPANY_NAME_MUST_CONTAIN_FIELD = "current_company.corporate_name";
     private static final String LOCATION_MATCH_FIELD = "current_company.full_address";
     private static final String INCORPORATION_DATE_MATCH_FIELD = "current_company.date_of_creation";
@@ -85,7 +88,7 @@ class EnhancedSearchQueriesTest {
     @DisplayName("Create sic codes match query")
     void sicCodesMatchQuery() {
         EnhancedSearchQueryParams enhancedSearchQueryParams = new EnhancedSearchQueryParams();
-        enhancedSearchQueryParams.setSicCodes(SIC_CODES);
+        enhancedSearchQueryParams.setSicCodes(SIC_CODES_LIST);
 
         QueryBuilder queryBuilder =
                 enhancedSearchQueries.buildEnhancedSearchQuery(enhancedSearchQueryParams);

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/EnhancedQueryParamMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/EnhancedQueryParamMapperTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -25,6 +27,7 @@ class EnhancedQueryParamMapperTest {
     private static final LocalDate INCORPORATED_TO_MAPPED = LocalDate.of(2002, 2, 2);
     private static final String BAD_DATE_FORMAT = "20010101";
     private static final String SIC_CODES = "99960";
+    private static final List<String> SIC_CODES_LIST = Arrays.asList(SIC_CODES);
 
     @Test
     @DisplayName("Test params mapped successfully")
@@ -32,13 +35,13 @@ class EnhancedQueryParamMapperTest {
 
         EnhancedQueryParamMapper enhancedQueryParamMapper = new EnhancedQueryParamMapper();
         EnhancedSearchQueryParams enhancedSearchQueryParams =
-                enhancedQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES);
+                enhancedQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, INCORPORATED_FROM, INCORPORATED_TO, SIC_CODES_LIST);
 
         assertEquals(COMPANY_NAME, enhancedSearchQueryParams.getCompanyName());
         assertEquals(LOCATION, enhancedSearchQueryParams.getLocation());
         assertEquals(INCORPORATED_FROM_MAPPED, enhancedSearchQueryParams.getIncorporatedFrom());
         assertEquals(INCORPORATED_TO_MAPPED, enhancedSearchQueryParams.getIncorporatedTo());
-        assertEquals(SIC_CODES, enhancedSearchQueryParams.getSicCodes());
+        assertEquals(SIC_CODES_LIST, enhancedSearchQueryParams.getSicCodes());
     }
 
     @Test
@@ -62,7 +65,7 @@ class EnhancedQueryParamMapperTest {
         EnhancedQueryParamMapper enhancedQueryParamMapper = new EnhancedQueryParamMapper();
 
         assertThrows(DateFormatException.class, () -> {
-                enhancedQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, BAD_DATE_FORMAT, BAD_DATE_FORMAT, SIC_CODES);
+                enhancedQueryParamMapper.mapEnhancedQueryParameters(COMPANY_NAME, LOCATION, BAD_DATE_FORMAT, BAD_DATE_FORMAT, SIC_CODES_LIST);
         });
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/enhanced/EnhancedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/enhanced/EnhancedSearchIndexServiceTest.java
@@ -38,7 +38,7 @@ class EnhancedSearchIndexServiceTest {
 
     private static final String COMPANY_NAME = "test company";
     private static final String SIC_CODES = "99960";
-    private static final List<String> SIC_CODES_LIST = Arrays.asList(SIC_CODES);
+    private static final List<String> SIC_CODES_LIST = Arrays.asList(SIC_CODES, "0000000");
     private static final String REQUEST_ID = "requestId";
 
     @Test
@@ -47,7 +47,7 @@ class EnhancedSearchIndexServiceTest {
 
         EnhancedSearchQueryParams enhancedSearchQueryParams = new EnhancedSearchQueryParams();
         enhancedSearchQueryParams.setCompanyName(COMPANY_NAME);
-        enhancedSearchQueryParams.setSicCodes(SIC_CODES);
+        enhancedSearchQueryParams.setSicCodes(SIC_CODES_LIST);
 
         when(mockEnhancedSearchRequestService.getSearchResults(enhancedSearchQueryParams, "request id"))
                 .thenReturn(createSearchResults(true, false));;


### PR DESCRIPTION
update sic codes query param to be a list of string values
update models sic codes to be a list
update query term matcher to search multi values for sic codes
update tests

Resolves: BI-8675