### PR TITLE
BI-9313 - Add configurable fallback query limits for alpha and dissolved alpha search

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.mapper.ElasticSearchResponseMapper;
@@ -45,9 +46,12 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
     @Autowired
     private ElasticSearchResponseMapper elasticSearchResponseMapper;
 
+    @Autowired
+    private EnvironmentReader environmentReader;
+
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
-    private static final int FALLBACK_QUERY_LIMIT = 25;
     private static final String TOP_LEVEL_ALPHABETICAL_KIND = "search#alphabetical-search";
+    private static final String ALPHABETICAL_FALLBACK_QUERY_LIMIT = "ALPHABETICAL_FALLBACK_QUERY_LIMIT";
 
     private Integer sizeAbove;
     private Integer sizeBelow;
@@ -139,10 +143,13 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
     }
 
     public SearchHits peelbackSearchRequest(SearchHits hits, String orderedAlphakey, String requestId)
-            throws IOException {
+        throws IOException {
+
+        Integer fallbackQueryLimit = environmentReader.getMandatoryInteger(ALPHABETICAL_FALLBACK_QUERY_LIMIT);
+
         for (int i = 0; i < orderedAlphakey.length(); i++) {
 
-            if (hits.getTotalHits().value > 0 || i == FALLBACK_QUERY_LIMIT) {
+            if (hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.SearchHits;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DissolvedSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
@@ -47,10 +48,13 @@ public class DissolvedSearchRequestService {
     @Autowired
     private ElasticSearchResponseMapper elasticSearchResponseMapper;
 
+    @Autowired
+    private EnvironmentReader environmentReader;
+
     private static final String TOP_KIND = "search#alphabetical-dissolved";
-    private static final int FALLBACK_QUERY_LIMIT = 25;
     private static final String RESULT_FOUND = "A result has been found";
     private static final String SEARCH_HITS = "searchHits";
+    private static final String DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT = "DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT";
     
     private Integer sizeAbove;
     private Integer sizeBelow;
@@ -230,10 +234,13 @@ public class DissolvedSearchRequestService {
     }
 
     public SearchHits peelbackSearchRequest(SearchHits hits, String orderedAlphaKey, String requestId)
-            throws IOException {
+        throws IOException {
+
+        Integer fallbackQueryLimit = environmentReader.getMandatoryInteger(DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT);
+
         for (int i = 0; i < orderedAlphaKey.length(); i++) {
 
-            if (hits.getTotalHits().value > 0 || i == FALLBACK_QUERY_LIMIT) {
+            if (hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.mapper.ElasticSearchResponseMapper;
@@ -56,6 +57,9 @@ class AlphabeticalSearchRequestServiceTest {
     @Mock
     private ElasticSearchResponseMapper mockElasticSearchResponseMapper;
 
+    @Mock
+    private EnvironmentReader mockEnvironmentReader;
+
     private static final String CORPORATE_NAME = "corporateName";
     private static final String TOP_HIT = "TEST COMPANY";
     private static final String ORDERED_ALPHA_KEY = "orderedAlphaKey";
@@ -69,6 +73,7 @@ class AlphabeticalSearchRequestServiceTest {
     private static final String COMPANY_TYPE = "ltd";
     private static final String COMPANY_PROFILE_LINK = "/company/00000000";
     private static final String KIND = "searchresults#dissolved-company";
+    private static final String ALPHABETICAL_FALLBACK_QUERY_LIMIT = "ALPHABETICAL_FALLBACK_QUERY_LIMIT";
 
     @Test
     @DisplayName("Test search request returns results successfully with best match query")
@@ -208,6 +213,7 @@ class AlphabeticalSearchRequestServiceTest {
 
         when(mockAlphabeticalSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
                 .thenReturn(createSearchHits());
+        doReturn(25).when(mockEnvironmentReader).getMandatoryInteger(ALPHABETICAL_FALLBACK_QUERY_LIMIT);
 
         SearchHits searchHits = searchRequestService.peelbackSearchRequest(createEmptySearchHits(), ORDERED_ALPHA_KEY,
                 REQUEST_ID);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DissolvedSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.mapper.ElasticSearchResponseMapper;
@@ -54,6 +56,9 @@ class DissolvedSearchRequestServiceTest {
     @Mock
     private ElasticSearchResponseMapper mockElasticSearchResponseMapper;
 
+    @Mock
+    private EnvironmentReader mockEnvironmentReader;
+
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);
 
     private static final String COMPANY_NAME = "TEST COMPANY";
@@ -75,6 +80,7 @@ class DissolvedSearchRequestServiceTest {
     private static final Integer START_INDEX = 0;
     private static final String SEARCH_BEFORE_VALUE = "search_before:1234";
     private static final String SEARCH_AFTER_VALUE = "search_after:1234";
+    private static final String DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT = "DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT";
 
     @Test
     @DisplayName("Test dissolved alphabetical search request returns results successfully with best match query")
@@ -445,6 +451,7 @@ class DissolvedSearchRequestServiceTest {
 
         when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
                 .thenReturn(createSearchHits(true, true, true, true));
+        doReturn(25).when(mockEnvironmentReader).getMandatoryInteger(DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT);
 
         SearchHits searchHits = dissolvedSearchRequestService.peelbackSearchRequest(createEmptySearchHits(),
                 ORDERED_ALPHA_KEY, REQUEST_ID);


### PR DESCRIPTION
This enables the limit in which the fallback query will remove characters to find a match configurable. Enabling performance and recall to be adapted to customer needs.
Resolves: BI-9313