### PR TITLE
add null check when mapping creation and cessation dates adv search

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapper.java
@@ -187,11 +187,11 @@ public class ElasticSearchResponseMapper {
         advancedCompany.setKind(SEARCH_RESULTS_COMPANY_KIND);
 
         if (STATUS_LIST.contains(advancedCompany.getCompanyStatus()) 
-                && currentCompanyMap.containsKey(DATE_OF_CESSATION)) {
+                && currentCompanyMap.containsKey(DATE_OF_CESSATION) && currentCompanyMap.get(DATE_OF_CESSATION) != null) {
             advancedCompany.setDateOfCessation(LocalDate.parse((String) currentCompanyMap.get(DATE_OF_CESSATION), advancedFormatter));
         }
 
-        if (currentCompanyMap.containsKey(DATE_OF_CREATION)) {
+        if (currentCompanyMap.containsKey(DATE_OF_CREATION) && currentCompanyMap.get(DATE_OF_CREATION) != null) {
             advancedCompany.setDateOfCreation(LocalDate.parse((String) currentCompanyMap.get(DATE_OF_CREATION), advancedFormatter));
         }
 

--- a/src/test/java/uk/gov/companieshouse/search/api/constants/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/constants/TestConstants.java
@@ -307,7 +307,8 @@ public static final String ADVANCED_RESPONSE_MISSING_FIELDS =
                 "\"company_number\" : \"00000000\"," +
                 "\"corporate_name\" : \"TEST COMPANY\"," +
                 "\"company_status\" : \"dissolved\"," +
-                "\"date_of_cessation\" : \"2010-05-01\"" +
+                "\"date_of_cessation\" : null," +
+                "\"date_of_creation\" : null" +
             "}," +
             "\"links\" : {" +
                 "\"self\" : \"/company/00000000\"" +

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapperTest.java
@@ -448,7 +448,7 @@ class ElasticSearchResponseMapperTest {
     }
 
     @Test
-    @DisplayName("Map advanced response successful with missing fields")
+    @DisplayName("Map advanced response successful with missing fields and null date of creation and cessation")
     void mapAdvancedResponseSuccessfulMissingFields() {
 
         SearchHits searchHits = createHits(ADVANCED_RESPONSE_MISSING_FIELDS);
@@ -460,6 +460,8 @@ class ElasticSearchResponseMapperTest {
         assertEquals(COMPANY_NUMBER, company.getCompanyNumber());
         assertEquals(COMPANY_STATUS, company.getCompanyStatus());
         assertEquals(COMPANY_KIND, company.getKind());
+        assertEquals(null, company.getDateOfCreation());
+        assertEquals(null, company.getDateOfCessation());
     }
 
     @Test


### PR DESCRIPTION
add null check when mapping creation and cessation dates for advanced search results 
update test to cover null values

Resolves: BI-10776