### PR TITLE
add 'removed' as company status to allow output of cessation date for ROE

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ElasticSearchResponseMapper.java
@@ -59,6 +59,7 @@ public class ElasticSearchResponseMapper {
         STATUS_LIST.add("dissolved");
         STATUS_LIST.add("closed");
         STATUS_LIST.add("converted-closed");
+        STATUS_LIST.add("removed");
     }
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);


### PR DESCRIPTION
add 'removed' as company status to allow output of cessation date for ROE

Resolves: ROE-109