### PR TITLE
GCI-2077 security update elastic search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <api-security-java.version>0.3.4</api-security-java.version>
 
         <!-- Elastic Search -->
-        <elasticsearch.version>7.4.0</elasticsearch.version>
+        <elasticsearch.version>7.9.2</elasticsearch.version>
         <spring-data-elasticsearch.version>3.2.0.RELEASE</spring-data-elasticsearch.version>
 
         <!-- Docker -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <api-security-java.version>0.3.4</api-security-java.version>
 
         <!-- Elastic Search -->
-        <elasticsearch.version>7.4.0</elasticsearch.version>
+        <elasticsearch.version>7.13.3</elasticsearch.version>
         <spring-data-elasticsearch.version>3.2.0.RELEASE</spring-data-elasticsearch.version>
 
         <!-- Docker -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <api-security-java.version>0.3.4</api-security-java.version>
 
         <!-- Elastic Search -->
-        <elasticsearch.version>7.13.3</elasticsearch.version>
+        <elasticsearch.version>7.4.0</elasticsearch.version>
         <spring-data-elasticsearch.version>3.2.0.RELEASE</spring-data-elasticsearch.version>
 
         <!-- Docker -->


### PR DESCRIPTION
GCI-2077:updated elasticsearch version back to "7.4.0" from "7.9.2"