### PR TITLE
Add disqualified officer put request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <api-security-java.version>0.3.4</api-security-java.version>
+        <private-api-sdk-java.version>2.0.160</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.4.0</elasticsearch.version>
@@ -142,6 +143,12 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-java</artifactId>
             <version>${api-sdk-java.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
 
         <dependency>

--- a/routes.yaml
+++ b/routes.yaml
@@ -6,4 +6,5 @@ routes:
   2: ^/alphabetical-search/companies/*
   3: ^/dissolved-search/companies
   4: ^/advanced-search/companies
+  5: ^/disqualified-search
   5: ^/search/healthcheck

--- a/src/main/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfig.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfig.java
@@ -24,6 +24,7 @@ public class ElasticSearchConfig {
     private static final String ALPHABETICAL_SEARCH_URL = "ELASTIC_SEARCH_URL";
     private static final String DISSOLVED_SEARCH_URL = "DISSOLVED_SEARCH_URL";
     private static final String ADVANCED_SEARCH_URL = "ADVANCED_SEARCH_URL";
+    private static final String DISQUALIFIED_SEARCH_URL = "DISQUALIFIED_SEARCH_URL";
 
     @Qualifier("alphabeticalClient")
     @Bean(destroyMethod = "close")
@@ -41,6 +42,12 @@ public class ElasticSearchConfig {
     @Bean(destroyMethod = "close")
     public RestHighLevelClient dissolvedRestClient() {
         return createClient(DISSOLVED_SEARCH_URL);
+    }
+
+    @Qualifier("disqualifiedClient")
+    @Bean(destroyMethod = "close")
+    public RestHighLevelClient disqualifiedRestClient() {
+        return createClient(DISQUALIFIED_SEARCH_URL);
     }
 
     public RestHighLevelClient createClient(String url) {

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -32,7 +32,7 @@ public class DisqualifiedSearchController {
         Map<String, Object> logMap = new HashMap<>();
         logMap.put(OFFICER_NAME, officer.getItems().get(0).getPersonName());
         logMap.put(UPSERT_OFFICER, officerId);
-        getLogger().info("Attempting to upsert a natural officer to disqualification search index" + officer.toString(), logMap);
+        getLogger().info("Attempting to upsert a natural officer to disqualification search index", logMap);
 
         ResponseObject responseObject;
 

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.search.api.controller;
+
+
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.OFFICER_NAME;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.UPSERT_OFFICER;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "/disqualified-search", produces = MediaType.APPLICATION_JSON_VALUE)
+public class DisqualifiedSearchController {
+
+    @Autowired
+    private ApiToResponseMapper apiToResponseMapper;
+
+    @PutMapping("/disqualified-officers/{officer_id}")
+    public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
+                                                       @Valid @RequestBody OfficerDisqualification officer) {
+
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put(OFFICER_NAME, officer.getItems().get(0).getPersonName());
+        logMap.put(UPSERT_OFFICER, officerId);
+        getLogger().info("Attempting to upsert a natural officer to disqualification search index" + officer.toString(), logMap);
+
+        ResponseObject responseObject;
+
+        if (officerId == null || officerId.isEmpty()) {
+            responseObject = new ResponseObject(ResponseStatus.UPSERT_ERROR);
+        } else {
+            //TODO - officer upsert
+            responseObject = new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
+        }
+        return apiToResponseMapper.map(responseObject);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -43,7 +43,9 @@ public class LoggingUtils {
     public static final String DISSOLVED_TO = "dissolved_to";
     public static final String SIC_CODES = "sic_codes";
     public static final String COMPANY_NAME_EXCLUDES = "company_name_excludes";
-
+    public static final String OFFICER_NAME = "officer_name";
+    public static final String UPSERT_OFFICER = "upsert_officer_id";
+    
     public static final String REQUEST_ID_LOG_KEY = "request_id";
     public static final String STATUS_LOG_KEY = "status";
     public static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";

--- a/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
@@ -31,6 +31,7 @@ class ElasticSearchConfigTest {
     private static final String ENV_READER_RESULT_ALPHABETICAL = "https://cluster-alphabetical.url.com";
     private static final String ENV_READER_RESULT_DISSOLVED = "https://cluster-dissolved.url.com";
     private static final String ENV_READER_RESULT_ADVANCED = "https://cluster-advanced.url.com";
+    private static final String ENV_READER_RESULT_DISQUALIFIED = "https://cluster-disqualified.url.com";
 
     @Test
     @DisplayName("Test calling create client returns a rest high level client for alphabetical search")
@@ -72,6 +73,20 @@ class ElasticSearchConfigTest {
 
         List<Node> nodes = restHighLevelClient.getLowLevelClient().getNodes();
         assertEquals(ENV_READER_RESULT_ADVANCED, nodes.get(0).getHost().toString());
+        assertEquals(1, restHighLevelClient.getLowLevelClient().getNodes().size());
+    }
+
+    @Test
+    @DisplayName("Test calling create client returns a rest high level client for disqualified search")
+    void testDisqualifiedRestClient() throws Exception {
+
+        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_DISQUALIFIED);
+
+        RestHighLevelClient restHighLevelClient = elasticSearchConfig.disqualifiedRestClient();
+        assertNotNull(restHighLevelClient);
+
+        List<Node> nodes = restHighLevelClient.getLowLevelClient().getNodes();
+        assertEquals(ENV_READER_RESULT_DISQUALIFIED, nodes.get(0).getHost().toString());
         assertEquals(1, restHighLevelClient.getLowLevelClient().getNodes().size());
     }
 

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
@@ -1,0 +1,152 @@
+package uk.gov.companieshouse.search.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_UPSERTED;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPSERT_ERROR;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.disqualification.DateOfBirth;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.api.model.delta.officers.AddressAPI;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DisqualifiedSearchControllerTest {
+
+    @Mock
+    private ApiToResponseMapper mockApiToResponseMapper;
+
+    @Captor
+    private ArgumentCaptor<ResponseObject> responseObjectCaptor;
+
+    @InjectMocks
+    private DisqualifiedSearchController disqualifiedSearchController;
+
+    @Test
+    @DisplayName("Test upsert returns a HTTP 200 Ok Response if the officer Id is presented")
+    void testUpsertWithCorrectOfficerIdReturnsOkRequest() {
+
+        testReturnsOkResponse("12345encode");
+    }
+
+    @Test
+    @DisplayName("Test upsert returns a HTTP 200 Ok Response if the officer Id is an empty string")
+    void testUpsertWithEmptyStringOfficerIdReturnsBadRequest() {
+
+        testReturnsBadRequest("");
+    }
+
+    private void testReturnsOkResponse(String officerId) {
+        OfficerDisqualification officer = createOfficer();
+
+        when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
+                .thenReturn(ResponseEntity.status(OK).build());
+
+        ResponseEntity<?> responseEntity = disqualifiedSearchController.upsertOfficer(officerId, officer);
+
+        assertEquals(DOCUMENT_UPSERTED, responseObjectCaptor.getValue().getStatus());
+        assertNotNull(responseEntity);
+        assertEquals(OK, responseEntity.getStatusCode());
+    }
+
+    private void testReturnsBadRequest(String officerId) {
+        OfficerDisqualification officer = createOfficer();
+
+        when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
+            .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
+
+        ResponseEntity<?> responseEntity = disqualifiedSearchController.upsertOfficer(officerId, officer);
+
+        assertEquals(UPSERT_ERROR, responseObjectCaptor.getValue().getStatus());
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+    }
+
+    private OfficerDisqualification createOfficer() {
+        OfficerDisqualification officer = new OfficerDisqualification();
+
+        officer.setDateOfBirth(buildDateOfBirth(officer));
+
+        officer.setKind("searchresults#disqualified-officer");
+
+        officer.setItems(buildItems(officer));
+
+        officer.setSortKey("Samson Thomas Lee1");
+
+        Map<String, String> links = new HashMap<>();
+        links.put("self", "/disqualified-officers/natural/12345encode");
+        officer.setLinks(links);
+
+        return officer;
+    }
+
+    public DateOfBirth buildDateOfBirth(OfficerDisqualification officer) {
+        DateOfBirth dateOfBirth = new DateOfBirth();
+        dateOfBirth.setYear("1990");
+        dateOfBirth.setMonth("06");
+        dateOfBirth.setDay("01");
+
+        return dateOfBirth;
+    }
+
+    public List<Item> buildItems(OfficerDisqualification officer) {
+        Item item = new Item();
+        List<Item> items = new ArrayList<>();
+
+        String disqualifiedFrom = "2020-08-16";
+        String disqualifiedUntil =  "2026-08-16";
+        LocalDate disqualifiedFromDate = LocalDate.parse(disqualifiedFrom);
+        LocalDate disqualifiedUntilDate = LocalDate.parse(disqualifiedUntil);
+
+        item.setPersonName("Thomas Lee SAMSON");
+        item.setForename("Thomas");
+        item.setRecordType("disqualifications");
+        item.setAddress(buildAddress());
+        item.setDisqualifiedFrom(disqualifiedFromDate);
+        item.setDisqualifiedUntil(disqualifiedUntilDate);
+        item.setOtherForenames("Lee");
+        item.setWildcardKey("Samson Thomas Lee1");
+        item.setSurname("SAMSON");
+        item.setFullAddress("1 Street, Castle, Castle, King County, King, KE1 1NN");
+
+        items.add(item);
+
+        return items;
+    }
+
+    public Object buildAddress() {
+        AddressAPI address = new AddressAPI();
+
+        address.setAddressLine1("Street");
+        address.setAddressLine2("Castle");
+        address.setCountry("King");
+        address.setPremises("1");
+        address.setLocality("Castle");
+        address.setPostcode("KE1 1NN");
+        address.setRegion("King County");
+
+        return address;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
@@ -52,7 +52,7 @@ class DisqualifiedSearchControllerTest {
     }
 
     @Test
-    @DisplayName("Test upsert returns a HTTP 200 Ok Response if the officer Id is an empty string")
+    @DisplayName("Test upsert returns a HTTP 400 Bad request if the officer Id is an empty string")
     void testUpsertWithEmptyStringOfficerIdReturnsBadRequest() {
 
         testReturnsBadRequest("");
@@ -93,7 +93,9 @@ class DisqualifiedSearchControllerTest {
 
         officer.setItems(buildItems(officer));
 
-        officer.setSortKey("Samson Thomas Lee1");
+        officer.setSortKey(officer.getItems().get(0).getSurname() + " " +
+                officer.getItems().get(0).getForename() + " " +
+                officer.getItems().get(0).getOtherForenames() + 1);
 
         Map<String, String> links = new HashMap<>();
         links.put("self", "/disqualified-officers/natural/12345encode");
@@ -126,8 +128,7 @@ class DisqualifiedSearchControllerTest {
         item.setAddress(buildAddress());
         item.setDisqualifiedFrom(disqualifiedFromDate);
         item.setDisqualifiedUntil(disqualifiedUntilDate);
-        item.setOtherForenames("Lee");
-        item.setWildcardKey("Samson Thomas Lee1");
+        item.setOtherForenames("SAMSON Thomas Lee1");
         item.setSurname("SAMSON");
         item.setFullAddress("1 Street, Castle, Castle, King County, King, KE1 1NN");
 


### PR DESCRIPTION
This PR is to add the put request endpoint so that the disqualified officer search consumer can successfully call on the search API to add/update a disqualified officer.

**Resolves**
DSND-819