### PR TITLE
Upsert disqualification to es6 elastic search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>1.1.0-rc1</api-helper-java.version>
         <api-security-java.version>0.3.4</api-security-java.version>
-        <private-api-sdk-java.version>2.0.163</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.164</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.4.0</elasticsearch.version>

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -1,21 +1,19 @@
 package uk.gov.companieshouse.search.api.controller;
 
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.UPSERT_OFFICER;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.upsert.disqualified.UpsertDisqualificationService;
 
 import javax.validation.Valid;
-import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -33,7 +31,7 @@ public class DisqualifiedSearchController {
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
                                                        @Valid @RequestBody OfficerDisqualification officer) {
 
-        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0), officerId);
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
         getLogger().info("Attempting to upsert an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;
@@ -44,16 +42,5 @@ public class DisqualifiedSearchController {
             responseObject = upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId);
         }
         return apiToResponseMapper.map(responseObject);
-    }
-
-    private Map<String, Object> setUpUpsertLogging(Item disqualification, String officerId) {
-        Map<String, Object> logMap = new HashMap<>();
-        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
-            logMap.put("officer name", disqualification.getCorporateName());
-        } else {
-            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
-        }
-        logMap.put(UPSERT_OFFICER, officerId);
-        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -39,7 +39,7 @@ public class DisqualifiedSearchController {
         if (officerId == null || officerId.isEmpty()) {
             responseObject = new ResponseObject(ResponseStatus.UPSERT_ERROR);
         } else {
-            responseObject = upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId);
+            responseObject = upsertDisqualificationService.upsertDisqualified(officer, officerId);
         }
         return apiToResponseMapper.map(responseObject);
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.search.api.controller;
 
-
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.OFFICER_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.UPSERT_OFFICER;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.search.api.controller;
 
 
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.OFFICER_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.UPSERT_OFFICER;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
@@ -34,9 +36,7 @@ public class DisqualifiedSearchController {
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
                                                        @Valid @RequestBody OfficerDisqualification officer) {
 
-        Map<String, Object> logMap = new HashMap<>();
-        logMap.put(OFFICER_NAME, officer.getItems().get(0).getPersonName());
-        logMap.put(UPSERT_OFFICER, officerId);
+        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0), officerId);
         getLogger().info("Attempting to upsert an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;
@@ -47,5 +47,16 @@ public class DisqualifiedSearchController {
             responseObject = upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId);
         }
         return apiToResponseMapper.map(responseObject);
+    }
+
+    private Map<String, Object> setUpUpsertLogging(Item disqualification, String officerId) {
+        Map<String, Object> logMap = new HashMap<>();
+        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
+            logMap.put("officer name", disqualification.getCorporateName());
+        } else {
+            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        }
+        logMap.put(UPSERT_OFFICER, officerId);
+        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.upsert.disqualified.UpsertDisqualificationService;
 
 import javax.validation.Valid;
 import java.util.HashMap;
@@ -24,6 +25,10 @@ public class DisqualifiedSearchController {
 
     @Autowired
     private ApiToResponseMapper apiToResponseMapper;
+
+    @Autowired
+    private UpsertDisqualificationService upsertDisqualificationService;
+
 
     @PutMapping("/disqualified-officers/{officer_id}")
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
@@ -39,8 +44,7 @@ public class DisqualifiedSearchController {
         if (officerId == null || officerId.isEmpty()) {
             responseObject = new ResponseObject(ResponseStatus.UPSERT_ERROR);
         } else {
-            //TODO - officer upsert
-            responseObject = new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
+            responseObject = upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId);
         }
         return apiToResponseMapper.map(responseObject);
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -37,7 +37,7 @@ public class DisqualifiedSearchController {
         Map<String, Object> logMap = new HashMap<>();
         logMap.put(OFFICER_NAME, officer.getItems().get(0).getPersonName());
         logMap.put(UPSERT_OFFICER, officerId);
-        getLogger().info("Attempting to upsert a natural officer to disqualification search index", logMap);
+        getLogger().info("Attempting to upsert an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;
 

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -26,7 +26,6 @@ public class DisqualifiedSearchController {
     @Autowired
     private UpsertDisqualificationService upsertDisqualificationService;
 
-
     @PutMapping("/disqualified-officers/{officer_id}")
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
                                                        @Valid @RequestBody OfficerDisqualification officer) {

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.search.api.elasticsearch;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class DisqualifiedSearchUpsertRequest {
+
+    public String buildRequest(OfficerDisqualification officer) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(LocalDate.class, new JsonSerializer<LocalDate>() {
+            @Override
+            public void serialize(LocalDate localDate, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+                if (localDate == null) {
+                    jsonGenerator.writeNull();
+                } else {
+                    DateTimeFormatter dateTimeFormatter =
+                            DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                    String format = localDate.atStartOfDay().format(dateTimeFormatter);
+                    jsonGenerator.writeRawValue("\"" + format + "\"");
+                }
+            }
+        });
+        mapper.registerModule(module);
+        return mapper.writeValueAsString(officer);
+    }
+}
+
+

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
@@ -1,40 +1,18 @@
 package uk.gov.companieshouse.search.api.elasticsearch;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 @Component
 public class DisqualifiedSearchUpsertRequest {
 
     public String buildRequest(OfficerDisqualification officer) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(LocalDate.class, new JsonSerializer<LocalDate>() {
-            @Override
-            public void serialize(LocalDate localDate, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-                if (localDate == null) {
-                    jsonGenerator.writeNull();
-                } else {
-                    DateTimeFormatter dateTimeFormatter =
-                            DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                    String format = localDate.atStartOfDay().format(dateTimeFormatter);
-                    jsonGenerator.writeRawValue("\"" + format + "\"");
-                }
-            }
-        });
-        mapper.registerModule(module);
         return mapper.writeValueAsString(officer);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -22,6 +22,7 @@ public class LoggingUtils {
     public static final String INDEX_ALPHABETICAL = "alphabetical_search_index";
     public static final String INDEX_DISSOLVED = "dissolved_search_index";
     public static final String ADVANCED_SEARCH_INDEX = "advanced_search_index";
+    public static final String DISQUALIFIED_SEARCH_INDEX = "primary_search";
     public static final String MESSAGE = "message";
     public static final String ORDERED_ALPHAKEY = "ordered_alphakey";
     public static final String SAME_AS_ALPHAKEYKEY = "same_as_alphakey";

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -4,6 +4,8 @@ import static uk.gov.companieshouse.search.api.SearchApiApplication.APPLICATION_
 
 import java.util.HashMap;
 import java.util.Map;
+
+import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
@@ -88,6 +90,17 @@ public class LoggingUtils {
         logMap.put(INDEX, LoggingUtils.ADVANCED_SEARCH_INDEX);
         getLogger().info("advanced search filters", logMap);
 
+        return logMap;
+    }
+
+    public static Map<String, Object> setUpDisqualifcationUpsertLogging(Item disqualification) {
+        Map<String, Object> logMap = new HashMap<>();
+        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
+            logMap.put("officer name", disqualification.getCorporateName());
+        } else {
+            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        }
+        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
         return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DisqualifiedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DisqualifiedSearchRestClientService.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.search.api.service.rest.impl;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.service.rest.RestClientService;
+
+import java.io.IOException;
+
+import static org.elasticsearch.client.RequestOptions.DEFAULT;
+
+@Service
+public class DisqualifiedSearchRestClientService implements RestClientService {
+
+    @Autowired
+    @Qualifier("disqualifiedClient")
+    private RestHighLevelClient disqualifiedClient;
+
+    @Override
+    public SearchResponse search(SearchRequest searchRequest) throws IOException {
+        return disqualifiedClient.search(searchRequest, DEFAULT);
+    }
+
+    @Override
+    public UpdateResponse upsert(UpdateRequest updateRequest) throws IOException {
+        return disqualifiedClient.update(updateRequest, RequestOptions.DEFAULT);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -4,17 +4,13 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
-
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
 
 @Service
 public class DisqualifiedUpsertRequestService {
@@ -34,7 +30,7 @@ public class DisqualifiedUpsertRequestService {
      */
     public UpdateRequest createUpdateRequest(OfficerDisqualification officer, String officerId) throws UpsertException {
 
-        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
         try {
 
             UpdateRequest request =  new UpdateRequest("primary_search", "primary_search", officerId)
@@ -48,16 +44,5 @@ public class DisqualifiedUpsertRequestService {
             LoggingUtils.getLogger().error("Failed to update a document for officer" + e.getMessage(), logMap);
             throw new UpsertException("Unable to create update request");
         }
-    }
-
-    private Map<String, Object> setUpUpsertLogging(Item disqualification) {
-        Map<String, Object> logMap = new HashMap<>();
-        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
-            logMap.put("officer name", disqualification.getCorporateName());
-        } else {
-            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
-        }
-        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
-        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -5,6 +5,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
@@ -17,6 +18,9 @@ public class DisqualifiedUpsertRequestService {
 
     @Autowired
     private DisqualifiedSearchUpsertRequest disqualifiedSearchUpsertRequest;
+
+    @Autowired
+    private EnvironmentReader environmentReader;
 
     private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
 
@@ -31,9 +35,10 @@ public class DisqualifiedUpsertRequestService {
     public UpdateRequest createUpdateRequest(OfficerDisqualification officer, String officerId) throws UpsertException {
 
         Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
-        try {
+        String index = environmentReader.getMandatoryString(INDEX);
 
-            UpdateRequest request =  new UpdateRequest("primary_search", "primary_search", officerId)
+        try {
+            UpdateRequest request =  new UpdateRequest(index, index, officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.search.api.service.upsert.disqualified;
+
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
+
+@Service
+public class DisqualifiedUpsertRequestService {
+
+    @Autowired
+    private DisqualifiedSearchUpsertRequest disqualifiedSearchUpsertRequest;
+
+    private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
+
+    /**
+     * If document already exists attempt to upsert the document
+     * Note: Uses a deprecated UpdateRequest method for ES6 index
+     * @param officer - Officer Disqualification sent over in REST call to be added/updated
+     *
+     * @return {@link UpdateRequest}
+     * @throws UpsertException
+     */
+    public UpdateRequest createUpdateRequest(OfficerDisqualification officer, String officerId) throws UpsertException {
+
+        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0));
+        try {
+
+            UpdateRequest request =  new UpdateRequest("primary_search", "primary_search", officerId)
+                    .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
+
+            LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist - my request" + request.toString(), logMap);
+
+            return request;
+
+        } catch (IOException e) {
+            LoggingUtils.getLogger().error("Failed to update a document for officer" + e.getMessage(), logMap);
+            throw new UpsertException("Unable to create update request");
+        }
+    }
+
+    private Map<String, Object> setUpUpsertLogging(Item disqualification) {
+        Map<String, Object> logMap = new HashMap<>();
+        logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
+        return logMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -52,7 +52,11 @@ public class DisqualifiedUpsertRequestService {
 
     private Map<String, Object> setUpUpsertLogging(Item disqualification) {
         Map<String, Object> logMap = new HashMap<>();
-        logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
+            logMap.put("officer name", disqualification.getCorporateName());
+        } else {
+            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        }
         logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
         return logMap;
     }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -40,7 +40,7 @@ public class DisqualifiedUpsertRequestService {
             UpdateRequest request =  new UpdateRequest("primary_search", "primary_search", officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
-            LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist - my request" + request.toString(), logMap);
+            LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);
 
             return request;
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -38,7 +38,7 @@ public class DisqualifiedUpsertRequestService {
         String index = environmentReader.getMandatoryString(INDEX);
 
         try {
-            UpdateRequest request =  new UpdateRequest(index, index, officerId)
+            UpdateRequest request = new UpdateRequest(index, index, officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -36,10 +36,7 @@ public class UpsertDisqualificationService {
      * @return {@link ResponseObject}
      */
     public ResponseObject upsertNaturalDisqualified(OfficerDisqualification officer, String officerId) {
-        Map<String, Object> logMap = new HashMap<>();
-        Item disqualification = officer.getItems().get(0);
-        logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
-        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
+        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0));
         getLogger().info("Upserting to disqualified index underway", logMap);
 
         UpdateRequest updateRequest;
@@ -60,5 +57,16 @@ public class UpsertDisqualificationService {
 
         getLogger().info("Upsert successful to disqualified search index", logMap);
         return new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
+    }
+
+    private Map<String, Object> setUpUpsertLogging(Item disqualification) {
+        Map<String, Object> logMap = new HashMap<>();
+        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
+            logMap.put("officer name", disqualification.getCorporateName());
+        } else {
+            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        }
+        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
+        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -3,19 +3,16 @@ package uk.gov.companieshouse.search.api.service.upsert.disqualified;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.rest.impl.DisqualifiedSearchRestClientService;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
 @Service
@@ -36,7 +33,7 @@ public class UpsertDisqualificationService {
      * @return {@link ResponseObject}
      */
     public ResponseObject upsertNaturalDisqualified(OfficerDisqualification officer, String officerId) {
-        Map<String, Object> logMap = setUpUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
         getLogger().info("Upserting to disqualified index underway", logMap);
 
         UpdateRequest updateRequest;
@@ -57,16 +54,5 @@ public class UpsertDisqualificationService {
 
         getLogger().info("Upsert successful to disqualified search index", logMap);
         return new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
-    }
-
-    private Map<String, Object> setUpUpsertLogging(Item disqualification) {
-        Map<String, Object> logMap = new HashMap<>();
-        if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
-            logMap.put("officer name", disqualification.getCorporateName());
-        } else {
-            logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
-        }
-        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
-        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.search.api.service.upsert.disqualified;
+
+import org.elasticsearch.action.update.UpdateRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.rest.impl.DisqualifiedSearchRestClientService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISQUALIFIED_SEARCH_INDEX;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
+
+@Service
+public class UpsertDisqualificationService {
+
+    @Autowired
+    private DisqualifiedSearchRestClientService disqualifiedSearchRestClientService;
+
+    @Autowired
+    private DisqualifiedUpsertRequestService disqualifiedUpsertRequestService;
+
+    /**
+     * Upserts a new document to disqualified search index for an officer.
+     * If a document does not exist it is added.
+     * If the document does exist it is updated.
+     *
+     * @param officer -  Officer Disqualification sent over in REST call to be added/updated
+     * @return {@link ResponseObject}
+     */
+    public ResponseObject upsertNaturalDisqualified(OfficerDisqualification officer, String officerId) {
+        Map<String, Object> logMap = new HashMap<>();
+        Item disqualification = officer.getItems().get(0);
+        logMap.put("officer name", disqualification.getForename() + " " + disqualification.getSurname());
+        logMap.put(INDEX, DISQUALIFIED_SEARCH_INDEX);
+        getLogger().info("Upserting to disqualified index underway", logMap);
+
+        UpdateRequest updateRequest;
+
+        try {
+            updateRequest = disqualifiedUpsertRequestService.createUpdateRequest(officer, officerId);
+        } catch (UpsertException e) {
+            getLogger().error("An error occured attempting upsert the document to disqualified search index", logMap);
+            return new ResponseObject(ResponseStatus.UPSERT_ERROR);
+        }
+
+        try {
+            disqualifiedSearchRestClientService.upsert(updateRequest);
+        } catch (IOException e) {
+            getLogger().error("IOException when upserting a officer to the disqualified search index", logMap);
+            return new ResponseObject(ResponseStatus.UPDATE_REQUEST_ERROR);
+        }
+
+        getLogger().info("Upsert successful to disqualified search index", logMap);
+        return new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -32,7 +32,7 @@ public class UpsertDisqualificationService {
      * @param officer -  Officer Disqualification sent over in REST call to be added/updated
      * @return {@link ResponseObject}
      */
-    public ResponseObject upsertNaturalDisqualified(OfficerDisqualification officer, String officerId) {
+    public ResponseObject upsertDisqualified(OfficerDisqualification officer, String officerId) {
         Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
         getLogger().info("Upserting to disqualified index underway", logMap);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
@@ -70,7 +70,7 @@ class DisqualifiedSearchControllerTest {
     private void testReturnsOkResponse(String officerId, boolean corporate) {
         OfficerDisqualification officer = createOfficer(corporate);
 
-        when(upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId))
+        when(upsertDisqualificationService.upsertDisqualified(officer, officerId))
                 .thenReturn(new ResponseObject(DOCUMENT_UPSERTED));
         when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
                 .thenReturn(ResponseEntity.status(OK).build());

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.api.model.delta.officers.AddressAPI;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.service.upsert.disqualified.UpsertDisqualificationService;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -39,6 +40,9 @@ class DisqualifiedSearchControllerTest {
 
     @Captor
     private ArgumentCaptor<ResponseObject> responseObjectCaptor;
+
+    @Mock
+    private UpsertDisqualificationService upsertDisqualificationService;
 
     @InjectMocks
     private DisqualifiedSearchController disqualifiedSearchController;
@@ -60,6 +64,8 @@ class DisqualifiedSearchControllerTest {
     private void testReturnsOkResponse(String officerId) {
         OfficerDisqualification officer = createOfficer();
 
+        when(upsertDisqualificationService.upsertNaturalDisqualified(officer, officerId))
+                .thenReturn(new ResponseObject(DOCUMENT_UPSERTED));
         when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
                 .thenReturn(ResponseEntity.status(OK).build());
 

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
@@ -1,0 +1,79 @@
+package uk.gov.companieshouse.search.api.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.disqualification.DateOfBirth;
+import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+
+import java.time.LocalDate;
+
+public class DisqualifiedSearchUpsertRequestTest {
+
+    private static final String FORENAME = "forename";
+    private static final String SURNAME = "surname";
+    private static final String SELF = "links";
+    private static final String SORT_KEY = "key";
+
+    private DisqualifiedSearchUpsertRequest request = new DisqualifiedSearchUpsertRequest();
+
+    @Test
+    public void officerIsTransformedToJSONString() throws Exception {
+        String actual = request.buildRequest(createOfficer());
+
+        String expected = createExpectedJSON();
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode actualNode = mapper.readTree(actual);
+        JsonNode expectedNode = mapper.readTree(expected);
+
+        assertEquals(expectedNode, actualNode);
+    }
+
+    private OfficerDisqualification createOfficer() {
+        OfficerDisqualification officer = new OfficerDisqualification();
+        Item item = new Item();
+        item.setForename(FORENAME);
+        item.setSurname(SURNAME);
+        item.setDisqualifiedFrom(LocalDate.of(2020, 1, 1));
+        item.setDisqualifiedUntil(LocalDate.of(2025, 1, 1));
+        officer.addItemsItem(item);
+        DateOfBirth dob = new DateOfBirth();
+        dob.setYear("2000");
+        dob.setMonth("01");
+        dob.setDay("01");
+        officer.setDateOfBirth(dob);
+        DisqualificationLinks links = new DisqualificationLinks();
+        links.setSelf(SELF);
+        officer.setLinks(links);
+        officer.setSortKey(SORT_KEY);
+        return officer;
+    }
+
+    private String createExpectedJSON() throws Exception {
+        JSONObject item = new JSONObject()
+                .put("forename", FORENAME)
+                .put("surname", SURNAME)
+                .put("disqualified_from", "2020-01-01")
+                .put("disqualified_until", "2025-01-01");
+        JSONObject dob = new JSONObject()
+                .put("year", "2000")
+                .put("month", "01")
+                .put("day", "01");
+        JSONObject links = new JSONObject()
+                .put("self", SELF);
+        JSONObject officer = new JSONObject()
+                .put("items", new JSONArray().put(item))
+                .put("date_of_birth", dob)
+                .put("links", links)
+                .put("sort_key", SORT_KEY);
+        return officer.toString();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
@@ -12,8 +12,6 @@ import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
 import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 
-import java.time.LocalDate;
-
 public class DisqualifiedSearchUpsertRequestTest {
 
     private static final String FORENAME = "forename";
@@ -42,8 +40,8 @@ public class DisqualifiedSearchUpsertRequestTest {
         Item item = new Item();
         item.setForename(FORENAME);
         item.setSurname(SURNAME);
-        item.setDisqualifiedFrom(LocalDate.of(2020, 1, 1));
-        item.setDisqualifiedUntil(LocalDate.of(2025, 1, 1));
+        item.setDisqualifiedFrom("2020-01-01");
+        item.setDisqualifiedUntil("2025-01-01");
         officer.addItemsItem(item);
         DateOfBirth dob = new DateOfBirth();
         dob.setYear("2000");

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.search.api.service.upsert.disqualified;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.elasticsearch.action.update.UpdateRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+
+import java.io.IOException;
+
+@ExtendWith(MockitoExtension.class)
+public class DisqualifiedUpsertRequestServiceTest {
+
+    private static final String UPDATE_JSON = "{\"example\":\"test\"}";
+    private static final String OFFICER_ID = "testid";
+
+    @Mock
+    private DisqualifiedSearchUpsertRequest disqualifiedSearchUpsertRequest;
+    @InjectMocks
+    private DisqualifiedUpsertRequestService service;
+
+    @Test
+    public void serviceCreatesUpdateRequest() throws Exception {
+        OfficerDisqualification officer = createOfficer();
+        when(disqualifiedSearchUpsertRequest.buildRequest(officer)).thenReturn(UPDATE_JSON);
+
+        UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
+
+        assertEquals(OFFICER_ID, request.id());
+        String expected = "update {[primary_search][primary_search][" + OFFICER_ID +
+                "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
+                "]}], scripted_upsert[false], detect_noop[true]}";
+        assertEquals(expected, request.toString());
+    }
+
+    @Test
+    public void serviceThrowsUpsertException() throws Exception {
+        OfficerDisqualification officer = createOfficer();
+        when(disqualifiedSearchUpsertRequest.buildRequest(officer)).thenThrow(new IOException());
+
+        Exception e = assertThrows(UpsertException.class,
+                () -> service.createUpdateRequest(officer, OFFICER_ID));
+
+        assertEquals("Unable to create update request", e.getMessage());
+    }
+
+    private OfficerDisqualification createOfficer() {
+        OfficerDisqualification officer = new OfficerDisqualification();
+        Item item = new Item();
+        item.setForename("Forename");
+        item.setSurname("Surname");
+        officer.addItemsItem(item);
+        return officer;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 
@@ -22,15 +23,20 @@ public class DisqualifiedUpsertRequestServiceTest {
 
     private static final String UPDATE_JSON = "{\"example\":\"test\"}";
     private static final String OFFICER_ID = "testid";
+    private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
+    private static final String PRIMARY = "primary_search";
 
     @Mock
     private DisqualifiedSearchUpsertRequest disqualifiedSearchUpsertRequest;
+    @Mock
+    private EnvironmentReader reader;
     @InjectMocks
     private DisqualifiedUpsertRequestService service;
 
     @Test
     public void serviceCreatesUpdateRequest() throws Exception {
         OfficerDisqualification officer = createOfficer();
+        when(reader.getMandatoryString(INDEX)).thenReturn(PRIMARY);
         when(disqualifiedSearchUpsertRequest.buildRequest(officer)).thenReturn(UPDATE_JSON);
 
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
@@ -45,6 +51,7 @@ public class DisqualifiedUpsertRequestServiceTest {
     @Test
     public void serviceThrowsUpsertException() throws Exception {
         OfficerDisqualification officer = createOfficer();
+        when(reader.getMandatoryString(INDEX)).thenReturn(PRIMARY);
         when(disqualifiedSearchUpsertRequest.buildRequest(officer)).thenThrow(new IOException());
 
         Exception e = assertThrows(UpsertException.class,

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.search.api.service.upsert.disqualified;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.calls;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.elasticsearch.action.update.UpdateRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.rest.impl.DisqualifiedSearchRestClientService;
+
+import java.io.IOException;
+
+@ExtendWith(MockitoExtension.class)
+public class UpsertDisqualificationServiceTest {
+
+    private static final String OFFICER_ID = "officerId";
+    private static final UpdateRequest request = new UpdateRequest();
+
+    @Mock
+    private DisqualifiedSearchRestClientService disqualifiedSearchRestClientService;
+    @Mock
+    private DisqualifiedUpsertRequestService disqualifiedUpsertRequestService;
+    @InjectMocks
+    private UpsertDisqualificationService service;
+
+    @Test
+    public void disqualificationIsUpsertedCorrectly() throws Exception {
+        OfficerDisqualification officer = createOfficer();
+        when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenReturn(request);
+
+        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+
+        assertEquals(ResponseStatus.DOCUMENT_UPSERTED, response.getStatus());
+        verify(disqualifiedSearchRestClientService).upsert(request);
+    }
+
+    @Test
+    public void disqualificationReturnsUpsertErrorIfUpsertException() throws Exception {
+        OfficerDisqualification officer = createOfficer();
+        when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenThrow(new UpsertException(""));
+
+        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+
+        assertEquals(ResponseStatus.UPSERT_ERROR, response.getStatus());
+    }
+
+    @Test
+    public void disqualificationReturnsUpdateErrorIfIOException() throws Exception {
+        OfficerDisqualification officer = createOfficer();
+        when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenReturn(request);
+        when(disqualifiedSearchRestClientService.upsert(request)).thenThrow(new IOException(""));
+
+        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+
+        assertEquals(ResponseStatus.UPDATE_REQUEST_ERROR, response.getStatus());
+    }
+
+    private OfficerDisqualification createOfficer() {
+        OfficerDisqualification officer = new OfficerDisqualification();
+        Item item = new Item();
+        item.setForename("Forename");
+        item.setSurname("Surname");
+        officer.addItemsItem(item);
+        return officer;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
@@ -38,7 +38,7 @@ public class UpsertDisqualificationServiceTest {
         OfficerDisqualification officer = createOfficer();
         when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenReturn(request);
 
-        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+        ResponseObject response = service.upsertDisqualified(officer, OFFICER_ID);
 
         assertEquals(ResponseStatus.DOCUMENT_UPSERTED, response.getStatus());
         verify(disqualifiedSearchRestClientService).upsert(request);
@@ -49,7 +49,7 @@ public class UpsertDisqualificationServiceTest {
         OfficerDisqualification officer = createOfficer();
         when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenThrow(new UpsertException(""));
 
-        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+        ResponseObject response = service.upsertDisqualified(officer, OFFICER_ID);
 
         assertEquals(ResponseStatus.UPSERT_ERROR, response.getStatus());
     }
@@ -60,7 +60,7 @@ public class UpsertDisqualificationServiceTest {
         when(disqualifiedUpsertRequestService.createUpdateRequest(officer, OFFICER_ID)).thenReturn(request);
         when(disqualifiedSearchRestClientService.upsert(request)).thenThrow(new IOException(""));
 
-        ResponseObject response = service.upsertNaturalDisqualified(officer, OFFICER_ID);
+        ResponseObject response = service.upsertDisqualified(officer, OFFICER_ID);
 
         assertEquals(ResponseStatus.UPDATE_REQUEST_ERROR, response.getStatus());
     }


### PR DESCRIPTION
This pr adds the upsert of disqualification records on the upsert PUT request. The upsert uses a deprecated update request method for compatibility with the ES6 elastic search primary_search index. As the data transformation is done in the consumer, the request only needs to be mapped to a json string before upserting.

**Resolves:**
- DSND-667