### PR TITLE
Add alphakey call for corporates without a sort key

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -30,7 +30,7 @@ public class DisqualifiedSearchController {
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
                                                        @Valid @RequestBody OfficerDisqualification officer) {
 
-        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0));
         getLogger().info("Attempting to upsert an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -93,7 +93,7 @@ public class LoggingUtils {
         return logMap;
     }
 
-    public static Map<String, Object> setUpDisqualifcationUpsertLogging(Item disqualification) {
+    public static Map<String, Object> setUpDisqualificationUpsertLogging(Item disqualification) {
         Map<String, Object> logMap = new HashMap<>();
         if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
             logMap.put("officer name", disqualification.getCorporateName());

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -61,14 +61,11 @@ public class DisqualifiedUpsertRequestService {
         }
     }
 
-    private void setKeyValues(OfficerDisqualification officer, Map<String, Object> logMap) throws UpsertException{
-
-        String orderedAlphaKey = "";
-
+    private void setKeyValues(OfficerDisqualification officer, Map<String, Object> logMap) throws UpsertException {
         AlphaKeyResponse alphaKeyResponse = alphaKeyService.getAlphaKeyForCorporateName(officer.getItems().get(0)
                 .getCorporateName());
         if (alphaKeyResponse != null) {
-            orderedAlphaKey = alphaKeyResponse.getOrderedAlphaKey() + "1";
+            String orderedAlphaKey = alphaKeyResponse.getOrderedAlphaKey() + "1";
             logMap.put(LoggingUtils.ORDERED_ALPHAKEY, orderedAlphaKey);
             officer.setSortKey(orderedAlphaKey);
             for (Item item: officer.getItems()) {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.search.api.service.upsert.disqualified;
 
+import uk.gov.companieshouse.api.disqualification.Item;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,8 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DisqualifiedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
+import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,6 +25,9 @@ public class DisqualifiedUpsertRequestService {
     @Autowired
     private EnvironmentReader environmentReader;
 
+    @Autowired
+    private AlphaKeyService alphaKeyService;
+
     private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
 
     /**
@@ -34,8 +40,12 @@ public class DisqualifiedUpsertRequestService {
      */
     public UpdateRequest createUpdateRequest(OfficerDisqualification officer, String officerId) throws UpsertException {
 
-        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0));
         String index = environmentReader.getMandatoryString(INDEX);
+
+        if (officer.getSortKey() == null || officer.getSortKey().equals("")) {
+            setKeyValues(officer, logMap);
+        }
 
         try {
             UpdateRequest request = new UpdateRequest(index, index, officerId)
@@ -48,6 +58,24 @@ public class DisqualifiedUpsertRequestService {
         } catch (IOException e) {
             LoggingUtils.getLogger().error("Failed to update a document for officer" + e.getMessage(), logMap);
             throw new UpsertException("Unable to create update request");
+        }
+    }
+
+    private void setKeyValues(OfficerDisqualification officer, Map<String, Object> logMap) throws UpsertException{
+
+        String orderedAlphaKey = "";
+
+        AlphaKeyResponse alphaKeyResponse = alphaKeyService.getAlphaKeyForCorporateName(officer.getItems().get(0)
+                .getCorporateName());
+        if (alphaKeyResponse != null) {
+            orderedAlphaKey = alphaKeyResponse.getOrderedAlphaKey() + "1";
+            logMap.put(LoggingUtils.ORDERED_ALPHAKEY, orderedAlphaKey);
+            officer.setSortKey(orderedAlphaKey);
+            for (Item item: officer.getItems()) {
+                item.setWildcardKey(orderedAlphaKey);
+            }
+        } else {
+            throw new UpsertException("Unable to create ordered alpha key");
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -33,7 +33,7 @@ public class UpsertDisqualificationService {
      * @return {@link ResponseObject}
      */
     public ResponseObject upsertDisqualified(OfficerDisqualification officer, String officerId) {
-        Map<String, Object> logMap = LoggingUtils.setUpDisqualifcationUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap = LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0));
         getLogger().info("Upserting to disqualified index underway", logMap);
 
         UpdateRequest updateRequest;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.search.api.service.upsert.disqualified;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.elasticsearch.action.update.UpdateRequest;
@@ -80,6 +81,7 @@ public class DisqualifiedUpsertRequestServiceTest {
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());
+        verify(alphaKeyService).getAlphaKeyForCorporateName(officer.getItems().get(0).getCorporateName());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -90,7 +90,7 @@ public class DisqualifiedUpsertRequestServiceTest {
         Exception e = assertThrows(UpsertException.class,
                 () -> service.createUpdateRequest(officer, OFFICER_ID));
 
-        assertEquals("Unable to create orderedAlphaKey", e.getMessage());
+        assertEquals("Unable to create ordered alpha key", e.getMessage());
     }
 
     private OfficerDisqualification createOfficer(boolean natural) {

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.search.api.service.upsert.disqualified;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
This PR adds an alphakey service call to create a sort key for corporates without one:

**Resolves**
DSND-869