### PR TITLE
Add hardcoded disqualified index type to match api.ch.gov.uk

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/delete/disqualified/DisqualifiedDeleteRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/delete/disqualified/DisqualifiedDeleteRequestService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class DisqualifiedDeleteRequestService {
 
     private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
+    private static final String TYPE = "primary_search";
 
     @Autowired
     private EnvironmentReader environmentReader;
@@ -21,7 +22,7 @@ public class DisqualifiedDeleteRequestService {
         Map<String, Object> logMap = LoggingUtils.setUpDisqualificationDeleteLogging(officerId);
         String index = environmentReader.getMandatoryString(INDEX);
 
-        DeleteRequest request = new DeleteRequest(index, index, officerId);
+        DeleteRequest request = new DeleteRequest(index, TYPE, officerId);
 
         LoggingUtils.getLogger().info("Attempt to delete officer if it exists", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -31,6 +31,7 @@ public class DisqualifiedUpsertRequestService {
     private AlphaKeyService alphaKeyService;
 
     private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
+    private static final String TYPE = "primary_search";
 
     /**
      * If document already exists attempt to upsert the document
@@ -51,7 +52,7 @@ public class DisqualifiedUpsertRequestService {
         }
 
         try {
-            UpdateRequest request = new UpdateRequest(index, index, officerId)
+            UpdateRequest request = new UpdateRequest(index, TYPE, officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/disqualified/DisqualifiedDeleteRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/disqualified/DisqualifiedDeleteRequestServiceTest.java
@@ -15,7 +15,8 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 @ExtendWith(MockitoExtension.class)
 public class DisqualifiedDeleteRequestServiceTest {
 
-    private static final String INDEX = "primary_search";
+    private static final String INDEX = "primary_search2";
+    private static final String TYPE = "primary_search";
     private static final String OFFICER_ID = "officerId";
 
     @Mock
@@ -35,6 +36,6 @@ public class DisqualifiedDeleteRequestServiceTest {
 
         assertEquals(OFFICER_ID, request.id());
         assertEquals(INDEX, request.index());
-        assertEquals(INDEX, request.type());
+        assertEquals(TYPE, request.type());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -27,7 +27,7 @@ public class DisqualifiedUpsertRequestServiceTest {
     private static final String UPDATE_JSON = "{\"example\":\"test\"}";
     private static final String OFFICER_ID = "testid";
     private static final String INDEX = "DISQUALIFIED_SEARCH_INDEX";
-    private static final String PRIMARY = "primary_search";
+    private static final String PRIMARY = "primary_search2";
 
     @Mock
     private DisqualifiedSearchUpsertRequest disqualifiedSearchUpsertRequest;
@@ -47,7 +47,7 @@ public class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search][primary_search][" + OFFICER_ID +
+        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());
@@ -77,7 +77,7 @@ public class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search][primary_search][" + OFFICER_ID +
+        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());


### PR DESCRIPTION
This pr hard codes the disqualified index type to match api.ch.gov.uk. This is done because the type is always primary_search, whereas the index can be different, e.g in staging it is primary_search2.

**Resolves:**
- DSND-1193