### PR TITLE
DSND-1879 Add disqualified search routes to UserAuthorisationInterceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
     </parent>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson.version>2.8.9</gson.version>
         <api-sdk-java.version>4.2.0</api-sdk-java.version>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
@@ -220,8 +222,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
                     <encoding>${project.build.sourceEncoding}</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <log4j.version>2.17.1</log4j.version>
 
         <!-- Maven and Surefire plugins -->
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
         <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
@@ -217,17 +216,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-compiler-plugin</artifactId>-->
-<!--                <version>${maven-compiler-plugin.version}</version>-->
-<!--                <configuration>-->
-<!--                    <fork>true</fork>-->
-<!--                    <meminitial>128m</meminitial>-->
-<!--                    <encoding>${project.build.sourceEncoding}</encoding>-->
-<!--                    <maxmem>512m</maxmem>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,17 +217,17 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <fork>true</fork>
-                    <meminitial>128m</meminitial>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <maxmem>512m</maxmem>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <version>${maven-compiler-plugin.version}</version>-->
+<!--                <configuration>-->
+<!--                    <fork>true</fork>-->
+<!--                    <meminitial>128m</meminitial>-->
+<!--                    <encoding>${project.build.sourceEncoding}</encoding>-->
+<!--                    <maxmem>512m</maxmem>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
@@ -28,6 +28,8 @@ public class SearchApiApplication implements WebMvcConfigurer {
         registry.addInterceptor(loggingInterceptor).excludePathPatterns("/search/healthcheck");
         registry.addInterceptor(authorisationInterceptor).addPathPatterns(
                 "/advanced-search/companies/{company_number}", 
-                "/alphabetical-search/companies/{company_number}");
+                "/alphabetical-search/companies/{company_number}",
+                "/disqualified-search/disqualified-officers/{officer_id}",
+                "/disqualified-search/delete/{officer_id}");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptor.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.search.api.interceptor;
 
-import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
@@ -36,7 +37,8 @@ public class UserAuthorisationInterceptor extends HandlerInterceptorAdapter {
         DataMap.Builder builder = new DataMap.Builder()
                 .requestId(request.getHeader(REQUEST_ID_HEADER_NAME));
 
-        if(AuthorisationUtil.hasInternalUserRole(request) && !GET.matches(request.getMethod())) {
+        if(AuthorisationUtil.hasInternalUserRole(request) &&
+                (PUT.matches(request.getMethod()) || DELETE.matches(request.getMethod()))) {
             getLogger().info("internal API is permitted to update the resource", builder.build().getLogMap());
             return true;
         } else {

--- a/src/main/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptor.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.search.api.interceptor;
 
-import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.REQUEST_ID_HEADER_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
@@ -36,7 +36,7 @@ public class UserAuthorisationInterceptor extends HandlerInterceptorAdapter {
         DataMap.Builder builder = new DataMap.Builder()
                 .requestId(request.getHeader(REQUEST_ID_HEADER_NAME));
 
-        if(AuthorisationUtil.hasInternalUserRole(request) && PUT.matches(request.getMethod())) {
+        if(AuthorisationUtil.hasInternalUserRole(request) && !GET.matches(request.getMethod())) {
             getLogger().info("internal API is permitted to update the resource", builder.build().getLogMap());
             return true;
         } else {

--- a/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -79,24 +79,4 @@ class UserAuthorisationInterceptorTest {
         doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
         assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
     }
-
-    @Test
-    @DisplayName("Does not authorise if GET and internal API key is not used")
-    void willNotAuthoriseIfRequestIsGetWithInternalAPIKey() {
-        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
-        doReturn("request-id").when(request).getHeader("X-Request-ID");
-        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
-        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
-        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
-    }
-
-    @Test
-    @DisplayName("Does not authorise if GET and internal API key is used")
-    void willNotAuthoriseIfRequestIsGetWithoutInternalAPIKey() {
-        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
-        doReturn("request-id").when(request).getHeader("X-Request-ID");
-        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
-        doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
-        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -79,4 +79,33 @@ class UserAuthorisationInterceptorTest {
         doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
         assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
     }
+
+    @Test
+    @DisplayName("Does not authorise if GET and internal API key is used")
+    void willNotAuthoriseIfRequestIsGetWithInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not authorise if PATCH and internal API key is used")
+    void willNotAuthoriseIfRequestIsPatchWithInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.PATCH.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+    @Test
+    @DisplayName("Does not authorise if POST and internal API key is used")
+    void willNotAuthoriseIfRequestIsPostWithInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.POST.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -79,4 +79,24 @@ class UserAuthorisationInterceptorTest {
         doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
         assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
     }
+
+    @Test
+    @DisplayName("Does not authorise if GET and internal API key is not used")
+    void willNotAuthoriseIfRequestIsGetWithInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not authorise if GET and internal API key is used")
+    void willNotAuthoriseIfRequestIsGetWithoutInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.GET.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/interceptor/UserAuthorisationInterceptorTest.java
@@ -59,4 +59,24 @@ class UserAuthorisationInterceptorTest {
         when(request.getHeader(ERIC_IDENTITY_TYPE)).thenReturn(INVALID_IDENTITY_TYPE_VALUE);
         assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
     }
+
+    @Test
+    @DisplayName("Authorise if DELETE and an internal API key is used")
+    void willAuthoriseIfRequestIsDeleteAndInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.DELETE.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertTrue(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
+
+    @Test
+    @DisplayName("Does not authorise if DELETE and internal API key is not used")
+    void willNotAuthoriseIfRequestIsDeleteAndNoInternalAPIKey() {
+        when(request.getMethod()).thenReturn(HttpMethod.DELETE.toString());
+        doReturn("request-id").when(request).getHeader("X-Request-ID");
+        doReturn(ERIC_IDENTITY_TYPE_API_KEY_VALUE).when(request).getHeader(ERIC_IDENTITY_TYPE);
+        doReturn("fake").when(request).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        assertFalse(userAuthorisationInterceptor.preHandle(request, response, null));
+    }
 }


### PR DESCRIPTION
* Change UserAuthorisationInterceptor to accept DELETE requests
* Tested locally and can confirm functionality works as expected.

Resolves [DSND-1879](https://companieshouse.atlassian.net/browse/DSND-1879)

[DSND-1879]: https://companieshouse.atlassian.net/browse/DSND-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ