### PR TITLE
BI-13524: Log the actual names of the indices used

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchController.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +32,7 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @RestController
 @RequestMapping(value = "/advanced-search", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -52,14 +52,22 @@ public class AdvancedSearchController {
     private static final String COMPANY_NAME_EXCLUDES = "company_name_excludes";
     private static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
     private static final String SIZE_PARAM = "size";
-    @Autowired
-    private AdvancedQueryParamMapper queryParamMapper;
-    @Autowired
-    private AdvancedSearchIndexService searchIndexService;
-    @Autowired
-    private ApiToResponseMapper apiToResponseMapper;
-    @Autowired
-    private UpsertCompanyService upsertCompanyService;
+
+    private final AdvancedQueryParamMapper queryParamMapper;
+    private final AdvancedSearchIndexService searchIndexService;
+    private final ApiToResponseMapper apiToResponseMapper;
+    private final UpsertCompanyService upsertCompanyService;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public AdvancedSearchController(AdvancedQueryParamMapper queryParamMapper,
+        AdvancedSearchIndexService searchIndexService, ApiToResponseMapper apiToResponseMapper,
+        UpsertCompanyService upsertCompanyService, ConfiguredIndexNamesProvider indices) {
+        this.queryParamMapper = queryParamMapper;
+        this.searchIndexService = searchIndexService;
+        this.apiToResponseMapper = apiToResponseMapper;
+        this.upsertCompanyService = upsertCompanyService;
+        this.indices = indices;
+    }
 
     @GetMapping("/companies")
     @ResponseBody
@@ -115,7 +123,7 @@ public class AdvancedSearchController {
                 .dissolvedTo(dissolvedToDate)
                 .companyNameExcludes(companyNameExcludes)
                 .size(String.valueOf(size))
-                .indexName(ADVANCED_SEARCH_INDEX)
+                .indexName(indices.advanced())
                 .build().getLogMap();
 
         getLogger().info("Search request received", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
@@ -1,13 +1,9 @@
 package uk.gov.companieshouse.search.api.controller;
 
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX_ALPHABETICAL;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
 import java.util.Map;
-
 import javax.validation.Valid;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,9 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.exception.SizeException;
@@ -31,6 +25,7 @@ import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestUtils;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 
 @RestController
@@ -44,14 +39,22 @@ public class AlphabeticalSearchController {
     private static final String SIZE_PARAM = "size";
     private static final String MAX_SIZE_PARAM = "MAX_SIZE_PARAM";
     private static final String ALPHABETICAL_SEARCH_RESULT_MAX = "ALPHABETICAL_SEARCH_RESULT_MAX";
-    @Autowired
-    private AlphabeticalSearchIndexService searchIndexService;
-    @Autowired
-    private UpsertCompanyService upsertCompanyService;
-    @Autowired
-    private ApiToResponseMapper apiToResponseMapper;
-    @Autowired
-    private EnvironmentReader environmentReader;
+
+    private final AlphabeticalSearchIndexService searchIndexService;
+    private final UpsertCompanyService upsertCompanyService;
+    private final ApiToResponseMapper apiToResponseMapper;
+    private final EnvironmentReader environmentReader;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public AlphabeticalSearchController(AlphabeticalSearchIndexService searchIndexService,
+        UpsertCompanyService upsertCompanyService, ApiToResponseMapper apiToResponseMapper,
+        EnvironmentReader environmentReader, ConfiguredIndexNamesProvider indices) {
+        this.searchIndexService = searchIndexService;
+        this.upsertCompanyService = upsertCompanyService;
+        this.apiToResponseMapper = apiToResponseMapper;
+        this.environmentReader = environmentReader;
+        this.indices = indices;
+    }
 
     @GetMapping("/companies")
     @ResponseBody
@@ -64,7 +67,7 @@ public class AlphabeticalSearchController {
         Map<String, Object> logMap = new DataMap.Builder()
                 .requestId(requestId)
                 .companyName(companyName)
-                .indexName(INDEX_ALPHABETICAL)
+                .indexName(indices.alphabetical())
                 .searchBefore(searchBefore)
                 .searchAfter(searchAfter)
                 .size(String.valueOf(size))

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchController.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.search.api.service.upsert.disqualified.UpsertDisqua
 
 import javax.validation.Valid;
 import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @RestController
 @RequestMapping(value = "/disqualified-search", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -30,20 +31,24 @@ public class DisqualifiedSearchController {
     private final ApiToResponseMapper apiToResponseMapper;
     private final UpsertDisqualificationService upsertDisqualificationService;
     private final PrimarySearchDeleteService primarySearchDeleteService;
+    private final ConfiguredIndexNamesProvider indices;
 
     public DisqualifiedSearchController(ApiToResponseMapper apiToResponseMapper,
             UpsertDisqualificationService upsertDisqualificationService,
-            PrimarySearchDeleteService primarySearchDeleteService) {
+            PrimarySearchDeleteService primarySearchDeleteService,
+        ConfiguredIndexNamesProvider indices) {
         this.apiToResponseMapper = apiToResponseMapper;
         this.upsertDisqualificationService = upsertDisqualificationService;
         this.primarySearchDeleteService = primarySearchDeleteService;
+        this.indices = indices;
     }
 
     @PutMapping("/disqualified-officers/{officer_id}")
     public ResponseEntity<Object> upsertOfficer(@PathVariable("officer_id") String officerId,
                                                        @Valid @RequestBody OfficerDisqualification officer) {
 
-        Map<String, Object> logMap = LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap =
+            LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0), indices);
         getLogger().info("Attempting to upsert an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;
@@ -58,7 +63,7 @@ public class DisqualifiedSearchController {
 
     @DeleteMapping("/delete/{officer_id}")
     public ResponseEntity<Object> deleteOfficer(@PathVariable("officer_id") String officerId) {
-        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(officerId);
+        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(officerId, indices);
         getLogger().info("Attempting to delete an officer to disqualification search index", logMap);
 
         ResponseObject responseObject;

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchController.java
@@ -4,7 +4,6 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.MESSAGE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,20 +21,12 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestUtils;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 
 @RestController
 @RequestMapping(value = "/dissolved-search", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DissolvedSearchController {
-
-    @Autowired
-    private DissolvedSearchIndexService searchIndexService;
-
-    @Autowired
-    private ApiToResponseMapper apiToResponseMapper;
-
-    @Autowired
-    private EnvironmentReader environmentReader;
 
     private static final String MAX_SIZE_PARAM = "MAX_SIZE_PARAM";
     private static final String DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX = "DISSOLVED_ALPHABETICAL_SEARCH_RESULT_MAX";
@@ -51,6 +42,22 @@ public class DissolvedSearchController {
     private static final String SEARCH_AFTER_PARAM = "search_after";
     private static final String SIZE_PARAM = "size";
 
+
+    private final DissolvedSearchIndexService searchIndexService;
+    private final ApiToResponseMapper apiToResponseMapper;
+    private final EnvironmentReader environmentReader;
+    private final ConfiguredIndexNamesProvider indices;
+
+
+    public DissolvedSearchController(DissolvedSearchIndexService searchIndexService,
+        ApiToResponseMapper apiToResponseMapper, EnvironmentReader environmentReader,
+        ConfiguredIndexNamesProvider indices) {
+        this.searchIndexService = searchIndexService;
+        this.apiToResponseMapper = apiToResponseMapper;
+        this.environmentReader = environmentReader;
+        this.indices = indices;
+    }
+
     @GetMapping("/companies")
     @ResponseBody
     public ResponseEntity<Object> searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
@@ -64,7 +71,7 @@ public class DissolvedSearchController {
         Map<String, Object> logMap = new DataMap.Builder()
                 .requestId(requestId)
                 .companyName(companyName)
-                .indexName(LoggingUtils.INDEX_DISSOLVED)
+                .indexName(indices.dissolved())
                 .searchBefore(searchBefore)
                 .searchAfter(searchAfter)
                 .size(String.valueOf(size))

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/OfficersSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/OfficersSearchController.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.delete.primary.PrimarySearchDeleteService;
 import uk.gov.companieshouse.search.api.service.upsert.officers.UpsertOfficersService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @RestController
 public class OfficersSearchController {
@@ -26,12 +27,15 @@ public class OfficersSearchController {
     private final ApiToResponseMapper apiToResponseMapper;
     private final UpsertOfficersService upsertOfficersService;
     private final PrimarySearchDeleteService primarySearchDeleteService;
+    private final ConfiguredIndexNamesProvider indices;
 
     public OfficersSearchController(ApiToResponseMapper apiToResponseMapper,
-            UpsertOfficersService upsertOfficersService, PrimarySearchDeleteService primarySearchDeleteService) {
+            UpsertOfficersService upsertOfficersService, PrimarySearchDeleteService primarySearchDeleteService,
+        ConfiguredIndexNamesProvider indices) {
         this.apiToResponseMapper = apiToResponseMapper;
         this.upsertOfficersService = upsertOfficersService;
         this.primarySearchDeleteService = primarySearchDeleteService;
+        this.indices = indices;
     }
 
     @PutMapping(value = "/officers-search/officers/{officer_id}")
@@ -44,7 +48,7 @@ public class OfficersSearchController {
 
     @DeleteMapping("/officers-search/officers/{officer_id}")
     public ResponseEntity<Object> deleteOfficer(@PathVariable("officer_id") String officerId) {
-        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(officerId);
+        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(officerId, indices);
         getLogger().info("Attempting to delete an officer from the primary search index", logMap);
 
         ResponseObject responseObject;

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequests.java
@@ -4,9 +4,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
@@ -14,20 +12,21 @@ import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClie
 
 import java.io.IOException;
 import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Component
 public class AdvancedSearchRequests {
 
-    @Autowired
-    private AdvancedSearchRestClientService restClientService;
+    private final AdvancedSearchRestClientService restClientService;
+    private final AdvancedSearchQueries advancedSearchQueries;
+    private final ConfiguredIndexNamesProvider indices;
 
-    @Autowired
-    private EnvironmentReader environmentReader;
-
-    @Autowired
-    private AdvancedSearchQueries advancedSearchQueries;
-
-    private static final String INDEX = "ADVANCED_SEARCH_INDEX";
+    public AdvancedSearchRequests(AdvancedSearchRestClientService restClientService,
+        AdvancedSearchQueries advancedSearchQueries, ConfiguredIndexNamesProvider indices) {
+        this.restClientService = restClientService;
+        this.advancedSearchQueries = advancedSearchQueries;
+        this.indices = indices;
+    }
 
     public SearchHits getCompanies(AdvancedSearchQueryParams queryParams, String requestId) throws IOException {
         Map<String, Object> logMap = new DataMap.Builder()
@@ -36,7 +35,7 @@ public class AdvancedSearchRequests {
         LoggingUtils.getLogger().info("Building advanced search request", logMap);
 
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(environmentReader.getMandatoryString(INDEX));
+        searchRequest.indices(indices.advanced());
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 public class LoggingUtils {
 
@@ -26,10 +27,6 @@ public class LoggingUtils {
     public static final String COMPANY_SUBTYPE = "company_subtype";
     public static final String DISSOLVED_SEARCH_ALPHABETICAL = "dissolved - alphabetical";
     public static final String INDEX = "index_name";
-    public static final String INDEX_ALPHABETICAL = "alphabetical_search_index";
-    public static final String INDEX_DISSOLVED = "dissolved_search_index";
-    public static final String ADVANCED_SEARCH_INDEX = "advanced_search_index";
-    public static final String PRIMARY_SEARCH_INDEX = "primary_search";
     public static final String MESSAGE = "message";
     public static final String ORDERED_ALPHAKEY = "ordered_alphakey";
     public static final String SAME_AS_ALPHAKEYKEY = "same_as_alphakey";
@@ -78,7 +75,10 @@ public class LoggingUtils {
         }
     }
 
-    public static Map<String, Object> getLogMap(AdvancedSearchQueryParams queryParams, String requestId) {
+    public static Map<String, Object> getAdvancedSearchLogMap(
+        AdvancedSearchQueryParams queryParams,
+        String requestId,
+        ConfiguredIndexNamesProvider indices) {
 
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
         Date incorporatedFromDate = null;
@@ -113,14 +113,16 @@ public class LoggingUtils {
                 .dissolvedFrom(dissolvedFromDate)
                 .dissolvedTo(dissolvedToDate)
                 .companyNameExcludes(queryParams.getCompanyNameExcludes())
-                .indexName(LoggingUtils.ADVANCED_SEARCH_INDEX)
+                .indexName(indices.advanced())
                 .build().getLogMap();
         getLogger().info("advanced search filters", logMap);
 
         return logMap;
     }
 
-    public static Map<String, Object> setUpDisqualificationUpsertLogging(Item disqualification) {
+    public static Map<String, Object> setUpDisqualificationUpsertLogging(
+        Item disqualification,
+        ConfiguredIndexNamesProvider indices) {
         String officerName;
         if (disqualification.getCorporateName() != null && disqualification.getCorporateName().length() > 0) {
             officerName = disqualification.getCorporateName();
@@ -129,20 +131,24 @@ public class LoggingUtils {
         }
         return new DataMap.Builder()
                 .officerName(officerName)
-                .indexName(PRIMARY_SEARCH_INDEX)
+                .indexName(indices.primary())
                 .build().getLogMap();
     }
 
-    public static Map<String, Object> setUpOfficersAppointmentsUpsertLogging(String officerId) {
+    public static Map<String, Object> setUpOfficersAppointmentsUpsertLogging(
+        String officerId,
+        ConfiguredIndexNamesProvider indices) {
         return new DataMap.Builder()
                 .officerId(officerId)
-                .indexName(PRIMARY_SEARCH_INDEX)
+                .indexName(indices.primary())
                 .build().getLogMap();
     }
 
-    public static Map<String, Object> setUpPrimarySearchDeleteLogging(String officerId) {
+    public static Map<String, Object> setUpPrimarySearchDeleteLogging(
+        String officerId,
+        ConfiguredIndexNamesProvider indices) {
         return new DataMap.Builder()
                 .officerId(officerId)
-                .indexName(PRIMARY_SEARCH_INDEX).build().getLogMap();
+                .indexName(indices.primary()).build().getLogMap();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestService.java
@@ -2,28 +2,29 @@ package uk.gov.companieshouse.search.api.service.delete.primary;
 
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.SearchType;
 
 import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class PrimarySearchDeleteRequestService {
-    private static final String INDEX = "PRIMARY_SEARCH_INDEX";
-    private static final String TYPE = "primary_search";
-    private final EnvironmentReader environmentReader;
 
-    public PrimarySearchDeleteRequestService(EnvironmentReader environmentReader) {
-        this.environmentReader = environmentReader;
+    private static final String TYPE = "primary_search";
+
+    private final ConfiguredIndexNamesProvider indices;
+
+    public PrimarySearchDeleteRequestService(ConfiguredIndexNamesProvider indices) {
+        this.indices = indices;
     }
 
     public DeleteRequest createDeleteRequest(SearchType searchType) {
 
-        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(searchType.getOfficerId());
-        String index = environmentReader.getMandatoryString(INDEX);
+        Map<String, Object> logMap =
+            LoggingUtils.setUpPrimarySearchDeleteLogging(searchType.getOfficerId(), indices);
 
-        DeleteRequest request = new DeleteRequest(index, TYPE, searchType.getOfficerId());
+        DeleteRequest request = new DeleteRequest(indices.primary(), TYPE, searchType.getOfficerId());
 
         LoggingUtils.getLogger().info(String.format("Attempting to delete an [%s] with given id: [%s] from primary search index",
                 searchType.getPrimarySearchType(), searchType.getOfficerId()), logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClien
 
 import java.io.IOException;
 import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
@@ -23,15 +24,20 @@ public class PrimarySearchDeleteService {
 
     private final PrimarySearchDeleteRequestService primarySearchDeleteRequestService;
 
+    private final ConfiguredIndexNamesProvider indices;
+
     public PrimarySearchDeleteService(PrimarySearchRestClientService primarySearchRestClientService,
-            PrimarySearchDeleteRequestService primarySearchDeleteRequestService) {
+            PrimarySearchDeleteRequestService primarySearchDeleteRequestService,
+        ConfiguredIndexNamesProvider indices) {
         this.primarySearchRestClientService = primarySearchRestClientService;
         this.primarySearchDeleteRequestService = primarySearchDeleteRequestService;
+        this.indices = indices;
     }
 
     public ResponseObject deleteOfficer(SearchType searchType) {
 
-        Map<String, Object> logMap = LoggingUtils.setUpPrimarySearchDeleteLogging(searchType.getOfficerId());
+        Map<String, Object> logMap =
+            LoggingUtils.setUpPrimarySearchDeleteLogging(searchType.getOfficerId(), indices);
         DeleteRequest deleteRequest = primarySearchDeleteRequestService.createDeleteRequest(searchType);
 
         DeleteResponse response;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/advanced/AdvancedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/advanced/AdvancedSearchIndexService.java
@@ -4,10 +4,9 @@ import static uk.gov.companieshouse.search.api.logging.LoggingUtils.MESSAGE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.NO_RESULTS_FOUND;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.STANDARD_ERROR_MESSAGE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SUCCESSFUL_SEARCH;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogMap;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getAdvancedSearchLogMap;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
@@ -17,16 +16,23 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 
 import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class AdvancedSearchIndexService {
 
-    @Autowired
-    private AdvancedSearchRequestService advancedSearchRequestService;
+    private final AdvancedSearchRequestService advancedSearchRequestService;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public AdvancedSearchIndexService(AdvancedSearchRequestService advancedSearchRequestService,
+        ConfiguredIndexNamesProvider indices) {
+        this.advancedSearchRequestService = advancedSearchRequestService;
+        this.indices = indices;
+    }
 
     public ResponseObject searchAdvanced(AdvancedSearchQueryParams queryParams, String requestId) {
 
-        Map<String, Object> logMap = getLogMap(queryParams, requestId);
+        Map<String, Object> logMap = getAdvancedSearchLogMap(queryParams, requestId, indices);
         logMap.remove(MESSAGE);
 
         SearchResults<Company> searchResults;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/advanced/AdvancedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/advanced/AdvancedSearchRequestService.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.search.api.service.search.impl.advanced;
 
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.MESSAGE;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogMap;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getAdvancedSearchLogMap;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
 import java.io.IOException;
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.elasticsearch.search.SearchHits;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
 import uk.gov.companieshouse.search.api.elasticsearch.AdvancedSearchRequests;
@@ -19,22 +18,28 @@ import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class AdvancedSearchRequestService {
 
-    @Autowired
-    private AdvancedSearchRequests advancedSearchRequests;
-
-    @Autowired
-    private ElasticSearchResponseMapper elasticSearchResponseMapper;
-
+    private final AdvancedSearchRequests advancedSearchRequests;
+    private final ElasticSearchResponseMapper elasticSearchResponseMapper;
+    private final ConfiguredIndexNamesProvider indices;
 
     private static final String RESULT_FOUND = "A result has been found";
 
+    public AdvancedSearchRequestService(AdvancedSearchRequests advancedSearchRequests,
+        ElasticSearchResponseMapper elasticSearchResponseMapper,
+        ConfiguredIndexNamesProvider indices) {
+        this.advancedSearchRequests = advancedSearchRequests;
+        this.elasticSearchResponseMapper = elasticSearchResponseMapper;
+        this.indices = indices;
+    }
+
     public SearchResults<Company> getSearchResults(AdvancedSearchQueryParams queryParams, String requestId) throws SearchException {
 
-        Map<String, Object> logMap = getLogMap(queryParams, requestId);
+        Map<String, Object> logMap = getAdvancedSearchLogMap(queryParams, requestId, indices);
 
         getLogger().info("Getting advanced search results", logMap);
         logMap.remove(MESSAGE);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchIndexService.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.search.api.service.search.impl.alphabetical;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
+
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.exception.SearchException;
@@ -10,17 +12,19 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
-
-import java.util.Map;
-
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX_ALPHABETICAL;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class AlphabeticalSearchIndexService implements SearchIndexService {
 
-    @Autowired
-    private SearchRequestService<Company> searchRequestService;
+    private final SearchRequestService<Company> searchRequestService;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public AlphabeticalSearchIndexService(SearchRequestService<Company> searchRequestService,
+        ConfiguredIndexNamesProvider indices) {
+        this.searchRequestService = searchRequestService;
+        this.indices = indices;
+    }
 
     /**
      * {@inheritDoc}
@@ -33,7 +37,7 @@ public class AlphabeticalSearchIndexService implements SearchIndexService {
         Map<String, Object> logMap = new DataMap.Builder()
                 .requestId(requestId)
                 .companyName(corporateName)
-                .indexName(INDEX_ALPHABETICAL)
+                .indexName(indices.alphabetical())
                 .searchBefore(searchBefore)
                 .searchAfter(searchAfter)
                 .size(String.valueOf(size))

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -1,14 +1,17 @@
 package uk.gov.companieshouse.search.api.service.search.impl.alphabetical;
 
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX_ALPHABETICAL;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.MESSAGE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.ORDERED_ALPHAKEY;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.ORDERED_ALPHAKEY_WITH_ID;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -21,27 +24,16 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class AlphabeticalSearchRequestService implements SearchRequestService {
 
-    @Autowired
-    private AlphaKeyService alphaKeyService;
-
-    @Autowired
-    private AlphabeticalSearchRequests alphabeticalSearchRequests;
-
-    @Autowired
-    private ElasticSearchResponseMapper elasticSearchResponseMapper;
-
-    @Autowired
-    private EnvironmentReader environmentReader;
+    private final AlphaKeyService alphaKeyService;
+    private final AlphabeticalSearchRequests alphabeticalSearchRequests;
+    private final ElasticSearchResponseMapper elasticSearchResponseMapper;
+    private final EnvironmentReader environmentReader;
+    private final ConfiguredIndexNamesProvider indices;
 
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
     private static final String TOP_LEVEL_ALPHABETICAL_KIND = "search#alphabetical-search";
@@ -49,6 +41,17 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
 
     private Integer sizeAbove;
     private Integer sizeBelow;
+
+    public AlphabeticalSearchRequestService(AlphaKeyService alphaKeyService,
+        AlphabeticalSearchRequests alphabeticalSearchRequests,
+        ElasticSearchResponseMapper elasticSearchResponseMapper,
+        EnvironmentReader environmentReader, ConfiguredIndexNamesProvider indices) {
+        this.alphaKeyService = alphaKeyService;
+        this.alphabeticalSearchRequests = alphabeticalSearchRequests;
+        this.elasticSearchResponseMapper = elasticSearchResponseMapper;
+        this.environmentReader = environmentReader;
+        this.indices = indices;
+    }
 
     /**
      * {@inheritDoc}
@@ -59,7 +62,7 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
         Map<String, Object> logMap = new DataMap.Builder()
                 .requestId(requestId)
                 .companyName(corporateName)
-                .indexName(INDEX_ALPHABETICAL)
+                .indexName(indices.alphabetical())
                 .searchBefore(searchBefore)
                 .searchAfter(searchAfter)
                 .size(String.valueOf(size))

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -1,34 +1,35 @@
 package uk.gov.companieshouse.search.api.service.search.impl.dissolved;
 
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.COMPANY_NAME;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.DISSOLVED_SEARCH_ALPHABETICAL;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.INDEX;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.MESSAGE;
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.SEARCH_TYPE;
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.exception.SearchException;
-import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
-
-import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class DissolvedSearchIndexService {
 
-    @Autowired
-    private DissolvedSearchRequestService dissolvedSearchRequestService;
+    private final DissolvedSearchRequestService dissolvedSearchRequestService;
+    private final ConfiguredIndexNamesProvider indices;
 
     private static final String SEARCHING_FOR_COMPANY_INFO = "searching for company";
     private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
     private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
+
+    public DissolvedSearchIndexService(DissolvedSearchRequestService dissolvedSearchRequestService,
+        ConfiguredIndexNamesProvider indices) {
+        this.dissolvedSearchRequestService = dissolvedSearchRequestService;
+        this.indices = indices;
+    }
 
     public ResponseObject searchAlphabetical(String companyName, String searchBefore, String searchAfter,
             Integer size, String requestId) {
@@ -36,7 +37,7 @@ public class DissolvedSearchIndexService {
                 .requestId(requestId)
                 .companyName(companyName)
                 .searchType(DISSOLVED_SEARCH_ALPHABETICAL)
-                .indexName(LoggingUtils.INDEX_DISSOLVED)
+                .indexName(indices.dissolved())
                 .searchBefore(searchBefore)
                 .searchAfter(searchAfter)
                 .size(String.valueOf(size))
@@ -69,7 +70,7 @@ public class DissolvedSearchIndexService {
                 .requestId(requestId)
                 .companyName(companyName)
                 .searchType(DISSOLVED_SEARCH_ALPHABETICAL)
-                .indexName(LoggingUtils.INDEX_DISSOLVED)
+                .indexName(indices.dissolved())
                 .startIndex(String.valueOf(startIndex))
                 .build().getLogMap();
         logMap.remove(MESSAGE);
@@ -99,15 +100,5 @@ public class DissolvedSearchIndexService {
         getLogger().info(NO_RESULTS_FOUND + "best match on a " + searchType + " dissolved company",
                 logMap);
         return new ResponseObject(ResponseStatus.SEARCH_NOT_FOUND, null);
-    }
-
-    private Map<String, Object> getLogMap(String companyName, String requestId, String searchType) {
-        Map<String, Object> logMap = LoggingUtils.createLoggingMap(requestId);
-        logMap.put(COMPANY_NAME, companyName);
-        logMap.put(SEARCH_TYPE, searchType);
-        logMap.put(INDEX, LoggingUtils.INDEX_DISSOLVED);
-        getLogger().info(SEARCHING_FOR_COMPANY_INFO, logMap);
-
-        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
@@ -20,26 +19,33 @@ import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClie
 import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.upsert.advanced.AdvancedUpsertRequestService;
 import uk.gov.companieshouse.search.api.service.upsert.alphabetical.AlphabeticalUpsertRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.*;
 
 @Service
 public class UpsertCompanyService {
 
-    @Autowired
-    private AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
+    private final AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
+    private final AdvancedSearchRestClientService advancedSearchRestClientService;
+    private final AlphabeticalUpsertRequestService alphabeticalUpsertRequestService;
+    private final AdvancedUpsertRequestService advancedUpsertRequestService;
+    private final AlphaKeyService alphaKeyService;
+    private final ConfiguredIndexNamesProvider indices;
 
-    @Autowired
-    private AdvancedSearchRestClientService advancedSearchRestClientService;
-
-    @Autowired
-    private AlphabeticalUpsertRequestService alphabeticalUpsertRequestService;
-
-    @Autowired
-    private AdvancedUpsertRequestService advancedUpsertRequestService;
-
-    @Autowired
-    private AlphaKeyService alphaKeyService;
+    public UpsertCompanyService(
+        AlphabeticalSearchRestClientService alphabeticalSearchRestClientService,
+        AdvancedSearchRestClientService advancedSearchRestClientService,
+        AlphabeticalUpsertRequestService alphabeticalUpsertRequestService,
+        AdvancedUpsertRequestService advancedUpsertRequestService, AlphaKeyService alphaKeyService,
+        ConfiguredIndexNamesProvider indices) {
+        this.alphabeticalSearchRestClientService = alphabeticalSearchRestClientService;
+        this.advancedSearchRestClientService = advancedSearchRestClientService;
+        this.alphabeticalUpsertRequestService = alphabeticalUpsertRequestService;
+        this.advancedUpsertRequestService = advancedUpsertRequestService;
+        this.alphaKeyService = alphaKeyService;
+        this.indices = indices;
+    }
 
     /**
      * Upserts a new document to the alphabetical search index.
@@ -53,7 +59,7 @@ public class UpsertCompanyService {
         Map<String, Object> logMap = new DataMap.Builder()
                 .companyName(company.getCompanyName())
                 .companyNumber(company.getCompanyNumber())
-                .indexName(INDEX_ALPHABETICAL)
+                .indexName(indices.alphabetical())
                 .build().getLogMap();
         getLogger().info("Upserting company underway", logMap);
 
@@ -91,7 +97,7 @@ public class UpsertCompanyService {
         Map<String, Object> logMap = new DataMap.Builder()
                 .companyName(company.getCompanyName())
                 .companyNumber(company.getCompanyNumber())
-                .indexName(ADVANCED_SEARCH_INDEX)
+                .indexName(indices.advanced())
                 .build().getLogMap();
         getLogger().info("Upserting to advanced index underway", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestService.java
@@ -1,31 +1,28 @@
 package uk.gov.companieshouse.search.api.service.upsert.advanced;
 
+import java.io.IOException;
+import java.util.Map;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
 import uk.gov.companieshouse.search.api.elasticsearch.AdvancedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static uk.gov.companieshouse.search.api.logging.LoggingUtils.ADVANCED_SEARCH_INDEX;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class AdvancedUpsertRequestService {
 
-    @Autowired
-    private EnvironmentReader environmentReader;
+    private final AdvancedSearchUpsertRequest advancedSearchUpsertRequest;
+    private final ConfiguredIndexNamesProvider indices;
 
-    @Autowired
-    private AdvancedSearchUpsertRequest advancedSearchUpsertRequest;
-
-    private static final String INDEX = "ADVANCED_SEARCH_INDEX";
+    public AdvancedUpsertRequestService(
+        AdvancedSearchUpsertRequest advancedSearchUpsertRequest,
+        ConfiguredIndexNamesProvider indices) {
+        this.advancedSearchUpsertRequest = advancedSearchUpsertRequest;
+        this.indices = indices;
+    }
 
     /**
      * If document already exists attempt to upsert the document
@@ -39,25 +36,17 @@ public class AdvancedUpsertRequestService {
         Map<String, Object> logMap = new DataMap.Builder()
                 .companyName(company.getCompanyName())
                 .companyNumber(company.getCompanyNumber())
-                .indexName(ADVANCED_SEARCH_INDEX)
+                .indexName(indices.advanced())
                 .build().getLogMap();
         try {
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);
 
-            return new UpdateRequest(environmentReader.getMandatoryString(INDEX), company.getCompanyNumber())
+            return new UpdateRequest(indices.advanced(), company.getCompanyNumber())
                 .docAsUpsert(true)
                 .doc(advancedSearchUpsertRequest.buildRequest(company, orderedAlphaKey, sameAsKey));
         } catch (IOException e) {
             LoggingUtils.getLogger().error("Failed to update a document for company", logMap);
             throw new UpsertException("Unable to create update request");
         }
-    }
-
-    private Map<String, Object> setUpUpsertLogging(CompanyProfileApi company) {
-        Map<String, Object> logMap = new HashMap<>();
-        logMap.put(LoggingUtils.COMPANY_NAME, company.getCompanyName());
-        logMap.put(LoggingUtils.COMPANY_NUMBER, company.getCompanyNumber());
-        logMap.put(LoggingUtils.INDEX, LoggingUtils.ADVANCED_SEARCH_INDEX);
-        return logMap;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationService.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import javax.naming.ServiceUnavailableException;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
 
@@ -22,11 +23,14 @@ public class UpsertDisqualificationService {
 
     private final PrimarySearchRestClientService primarySearchRestClientService;
     private final DisqualifiedUpsertRequestService disqualifiedUpsertRequestService;
+    private final ConfiguredIndexNamesProvider indices;
 
     public UpsertDisqualificationService(PrimarySearchRestClientService primarySearchRestClientService,
-            DisqualifiedUpsertRequestService disqualifiedUpsertRequestService) {
+            DisqualifiedUpsertRequestService disqualifiedUpsertRequestService,
+        ConfiguredIndexNamesProvider indices) {
         this.primarySearchRestClientService = primarySearchRestClientService;
         this.disqualifiedUpsertRequestService = disqualifiedUpsertRequestService;
+        this.indices = indices;
     }
 
     /**
@@ -38,7 +42,8 @@ public class UpsertDisqualificationService {
      * @return {@link ResponseObject}
      */
     public ResponseObject upsertDisqualified(OfficerDisqualification officer, String officerId) {
-        Map<String, Object> logMap = LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0));
+        Map<String, Object> logMap =
+            LoggingUtils.setUpDisqualificationUpsertLogging(officer.getItems().get(0), indices);
         getLogger().info("Upserting to disqualified index underway", logMap);
 
         UpdateRequest updateRequest;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
@@ -10,31 +10,31 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.officer.AppointmentList;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.esdatamodel.OfficerSearchDocument;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class OfficersUpsertRequestService {
 
-    private final EnvironmentReader environmentReader;
-    private static final String INDEX = "PRIMARY_SEARCH_INDEX";
     private static final String TYPE = "primary_search";
     private final ConversionService conversionService;
     private final ObjectMapper mapper;
+    private final ConfiguredIndexNamesProvider indices;
 
-    public OfficersUpsertRequestService(EnvironmentReader environmentReader, @Lazy ConversionService conversionService, ObjectMapper mapper) {
-        this.environmentReader = environmentReader;
+    public OfficersUpsertRequestService(@Lazy ConversionService conversionService, ObjectMapper mapper,
+        ConfiguredIndexNamesProvider indices) {
         this.conversionService = conversionService;
         this.mapper = mapper;
+        this.indices = indices;
     }
 
     public UpdateRequest createUpdateRequest(AppointmentList appointmentList, String officerId)
             throws UpsertException {
 
-        Map<String, Object> logMap = LoggingUtils.setUpOfficersAppointmentsUpsertLogging(officerId);
-        String index = environmentReader.getMandatoryString(INDEX);
+        Map<String, Object> logMap =
+            LoggingUtils.setUpOfficersAppointmentsUpsertLogging(officerId, indices);
 
         OfficerSearchDocument documentToBeUpserted = Optional.ofNullable(conversionService.convert(appointmentList, OfficerSearchDocument.class))
                 .orElseThrow();
@@ -42,7 +42,7 @@ public class OfficersUpsertRequestService {
         try {
             String jsonString = mapper.writeValueAsString(documentToBeUpserted);
 
-            return new UpdateRequest(index, TYPE, officerId)
+            return new UpdateRequest(indices.primary(), TYPE, officerId)
                     .docAsUpsert(true).doc(jsonString, XContentType.JSON);
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/UpsertOfficersService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/UpsertOfficersService.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClientService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @Service
 public class UpsertOfficersService {
@@ -21,14 +22,19 @@ public class UpsertOfficersService {
 
     private final OfficersUpsertRequestService officersUpsertRequestService;
 
+    private final ConfiguredIndexNamesProvider indices;
+
     public UpsertOfficersService(PrimarySearchRestClientService primarySearchRestClientService,
-            OfficersUpsertRequestService officersUpsertRequestService) {
+            OfficersUpsertRequestService officersUpsertRequestService,
+        ConfiguredIndexNamesProvider indices) {
         this.primarySearchRestClientService = primarySearchRestClientService;
         this.officersUpsertRequestService = officersUpsertRequestService;
+        this.indices = indices;
     }
 
     public ResponseObject upsertOfficers(AppointmentList appointmentList, String officerId) {
-        Map<String, Object> logMap = LoggingUtils.setUpOfficersAppointmentsUpsertLogging(officerId);
+        Map<String, Object> logMap =
+            LoggingUtils.setUpOfficersAppointmentsUpsertLogging(officerId, indices);
         getLogger().info("Upserting officer's appointments to primary index", logMap);
 
         UpdateRequest updateRequest;

--- a/src/main/java/uk/gov/companieshouse/search/api/util/ConfiguredIndexNamesProvider.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/util/ConfiguredIndexNamesProvider.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.search.api.util;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+
+@Component
+public class ConfiguredIndexNamesProvider {
+
+    private static final String ALPHABETICAL_SEARCH_INDEX_ENVIRONMENT_VARIABLE = "ALPHABETICAL_SEARCH_INDEX";
+    private static final String DISSOLVED_SEARCH_INDEX_ENVIRONMENT_VARIABLE = "DISSOLVED_SEARCH_INDEX";
+    private static final String ADVANCED_SEARCH_INDEX_ENVIRONMENT_VARIABLE = "ADVANCED_SEARCH_INDEX";
+    private static final String PRIMARY_SEARCH_INDEX_ENVIRONMENT_VARIABLE = "PRIMARY_SEARCH_INDEX";
+
+    private final EnvironmentReader environment;
+
+    public ConfiguredIndexNamesProvider(EnvironmentReader environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * @return the value of the {@link #ALPHABETICAL_SEARCH_INDEX_ENVIRONMENT_VARIABLE} environment variable
+     */
+    public String alphabetical() {
+        return environment.getMandatoryString(ALPHABETICAL_SEARCH_INDEX_ENVIRONMENT_VARIABLE);
+    }
+
+    /**
+     * @return the value of the {@link #DISSOLVED_SEARCH_INDEX_ENVIRONMENT_VARIABLE} environment variable
+     */
+    public String dissolved() {
+        return environment.getMandatoryString(DISSOLVED_SEARCH_INDEX_ENVIRONMENT_VARIABLE);
+    }
+
+    /**
+     * @return the value of the {@link #ADVANCED_SEARCH_INDEX_ENVIRONMENT_VARIABLE} environment variable
+     */
+    public String advanced() {
+        return environment.getMandatoryString(ADVANCED_SEARCH_INDEX_ENVIRONMENT_VARIABLE);
+    }
+
+    /**
+     * @return the value of the {@link #PRIMARY_SEARCH_INDEX_ENVIRONMENT_VARIABLE} environment variable
+     */
+    public String primary() {
+        return environment.getMandatoryString(PRIMARY_SEARCH_INDEX_ENVIRONMENT_VARIABLE);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerTest.java
@@ -29,9 +29,12 @@ import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEA
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPDATE_REQUEST_ERROR;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPSERT_ERROR;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -53,14 +56,9 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdvancedSearchControllerTest {
 
     @Mock
@@ -77,6 +75,9 @@ class AdvancedSearchControllerTest {
 
     @Mock
     private UpsertCompanyService mockUpsertCompanyService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @Captor
     private ArgumentCaptor<ResponseObject> responseObjectCaptor;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
@@ -21,10 +21,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -32,19 +30,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
-
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.search.api.controller.AlphabeticalSearchController;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlphabeticalSearchControllerTest {
 
     @Mock
@@ -61,6 +57,9 @@ class AlphabeticalSearchControllerTest {
 
     @Mock
     private EnvironmentReader mockEnvironmentReader;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     private AlphabeticalSearchController alphabeticalSearchController;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DisqualifiedSearchControllerTest.java
@@ -34,6 +34,7 @@ import uk.gov.companieshouse.search.api.service.upsert.disqualified.UpsertDisqua
 
 import java.util.ArrayList;
 import java.util.List;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class DisqualifiedSearchControllerTest {
@@ -51,6 +52,9 @@ class DisqualifiedSearchControllerTest {
 
     @Mock
     private PrimarySearchDeleteService primarySearchDeleteService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     private DisqualifiedSearchController disqualifiedSearchController;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchControllerTest.java
@@ -11,9 +11,10 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SIZE_PARAMETER_ERROR;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -28,12 +29,9 @@ import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
-
-import java.util.ArrayList;
-import java.util.List;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DissolvedSearchControllerTest {
 
     @Mock
@@ -44,6 +42,9 @@ class DissolvedSearchControllerTest {
 
     @Mock
     private EnvironmentReader mockEnvironmentReader;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @Captor
     private ArgumentCaptor<ResponseObject> responseObjectCaptor;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/OfficersSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/OfficersSearchControllerTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.service.delete.primary.PrimarySearchDeleteService;
 import uk.gov.companieshouse.search.api.service.upsert.officers.UpsertOfficersService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class OfficersSearchControllerTest {
@@ -38,6 +39,8 @@ class OfficersSearchControllerTest {
     private PrimarySearchDeleteService primarySearchDeleteService;
     @Mock
     private UpsertOfficersService upsertOfficersService;
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
     @InjectMocks
     private OfficersSearchController officersSearchController;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequestsTest.java
@@ -4,7 +4,6 @@ import static org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.apache.lucene.search.TotalHits;
@@ -23,9 +22,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.model.AdvancedSearchQueryParams;
 import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClientService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -35,13 +34,13 @@ class AdvancedSearchRequestsTest {
     private AdvancedSearchRequests advancedSearchRequests;
 
     @Mock
-    private EnvironmentReader mockEnvironmentReader;
-
-    @Mock
     private AdvancedSearchQueries mockAdvancedSearchQueries;
 
     @Mock
     private AdvancedSearchRestClientService mockSearchRestClient;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     private static final String COMPANY_NAME = "TEST COMPANY";
     private static final String ENV_READER_RESULT = "ADVANCED_SEARCH_INDEX";
@@ -50,9 +49,8 @@ class AdvancedSearchRequestsTest {
     @Test
     @DisplayName("Get company number (must contain) response")
     void getCompanyNumberMustContainSuccessful() throws Exception {
-
-        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT);
         when(mockSearchRestClient.search(any(SearchRequest.class))).thenReturn(createSearchResponse());
+        when(indices.advanced()).thenReturn(ENV_READER_RESULT);
 
         SearchHits searchHits = advancedSearchRequests.getCompanies(createAdvancedSearchQueryParams(), REQUEST_ID);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestServiceTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.model.SearchType;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class PrimarySearchDeleteRequestServiceTest {
@@ -20,15 +20,16 @@ class PrimarySearchDeleteRequestServiceTest {
     private final String TYPE = "primary_search";
     private final String OFFICER_ID = "officerId";
     private final String PRIMARY_SEARCH_TYPE = "disqualified-officer";
+
     @Mock
-    EnvironmentReader reader;
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     PrimarySearchDeleteRequestService service;
 
     @BeforeEach
     void setup() {
-        when(reader.getMandatoryString("PRIMARY_SEARCH_INDEX")).thenReturn(INDEX);
+        when(indices.primary()).thenReturn(INDEX);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClientService;
 
 import java.io.IOException;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class PrimarySearchDeleteServiceTest {
@@ -29,6 +30,8 @@ class PrimarySearchDeleteServiceTest {
     PrimarySearchRestClientService primarySearchRestClientService;
     @Mock
     PrimarySearchDeleteRequestService primarySearchDeleteRequestService;
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     PrimarySearchDeleteService service;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchIndexServiceTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,9 +24,9 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdvancedSearchIndexServiceTest {
 
     @InjectMocks
@@ -35,6 +34,9 @@ class AdvancedSearchIndexServiceTest {
 
     @Mock
     private AdvancedSearchRequestService mockAdvancedSearchRequestService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     private static final String COMPANY_NAME = "test company";
     private static final String SIC_CODES = "99960";

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchRequestServiceTest.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -31,9 +30,9 @@ import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Links;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdvancedSearchRequestServiceTest {
 
     @Mock
@@ -41,6 +40,9 @@ class AdvancedSearchRequestServiceTest {
 
     @Mock
     private ElasticSearchResponseMapper mockElasticSearchResponseMapper;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     private AdvancedSearchRequestService searchRequestService;

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
@@ -1,9 +1,14 @@
 package uk.gov.companieshouse.search.api.service.search.alphabetical;
 
-import org.junit.jupiter.api.BeforeAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -15,32 +20,27 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Links;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
-import uk.gov.companieshouse.search.api.service.search.SearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.SearchRequestService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlphabeticalSearchIndexServiceTest {
 
     @InjectMocks
-    private SearchIndexService searchIndexService = new AlphabeticalSearchIndexService();
+    private AlphabeticalSearchIndexService searchIndexService;
 
     @Mock
     private SearchRequestService mockSearchRequestService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     private TopHit TOP_HIT;
     private static final String REQUEST_ID = "requestId";
     private static final String CORPORATE_NAME = "corporateName";
 
-    @BeforeAll
+    @BeforeEach
     void setUp() {
         TOP_HIT = new TopHit();
         TOP_HIT.setCompanyName("AAAA COMMUNICATIONS LIMITED");

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -17,12 +16,10 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
@@ -34,9 +31,9 @@ import uk.gov.companieshouse.search.api.model.esdatamodel.Links;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlphabeticalSearchRequestServiceTest {
 
     @InjectMocks
@@ -53,6 +50,9 @@ class AlphabeticalSearchRequestServiceTest {
 
     @Mock
     private EnvironmentReader mockEnvironmentReader;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     private static final String CORPORATE_NAME = "corporateName";
     private static final String TOP_HIT = "TEST COMPANY";

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchIndexServiceTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,9 +23,9 @@ import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DissolvedSearchIndexServiceTest {
 
     @InjectMocks
@@ -34,6 +33,9 @@ class DissolvedSearchIndexServiceTest {
 
     @Mock
     private DissolvedSearchRequestService mockDissolvedSearchRequestService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     private static final String REQUEST_ID = "requestId";
     private static final String COMPANY_NAME = "companyName";

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -22,7 +22,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -31,21 +30,21 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.DissolvedSearchRequests;
 import uk.gov.companieshouse.search.api.exception.SearchException;
 import uk.gov.companieshouse.search.api.mapper.ElasticSearchResponseMapper;
-import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.SearchResults;
+import uk.gov.companieshouse.search.api.model.TopHit;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Address;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.esdatamodel.PreviousCompanyName;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 import uk.gov.companieshouse.search.api.service.search.impl.dissolved.DissolvedSearchRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DissolvedSearchRequestServiceTest {
 
     @InjectMocks
-    private DissolvedSearchRequestService dissolvedSearchRequestService = new DissolvedSearchRequestService();
+    private DissolvedSearchRequestService dissolvedSearchRequestService;
 
     @Mock
     private AlphaKeyService mockAlphaKeyService;
@@ -58,6 +57,9 @@ class DissolvedSearchRequestServiceTest {
 
     @Mock
     private EnvironmentReader mockEnvironmentReader;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ENGLISH);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.search.api.service.upsert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_UPSERTED;
@@ -12,17 +11,14 @@ import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPS
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
@@ -32,9 +28,9 @@ import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClie
 import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.upsert.advanced.AdvancedUpsertRequestService;
 import uk.gov.companieshouse.search.api.service.upsert.alphabetical.AlphabeticalUpsertRequestService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UpsertCompanyServiceTest {
 
     @Mock
@@ -52,6 +48,12 @@ class UpsertCompanyServiceTest {
     @Mock
     private AlphaKeyService mockAlphaKeyService;
 
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
+
+    @Mock
+    private UpdateRequest updateRequest;
+
     @InjectMocks
     private UpsertCompanyService upsertCompanyService;
 
@@ -67,7 +69,7 @@ class UpsertCompanyServiceTest {
 
         when(mockAlphabeticalUpsertRequestService.createIndexRequest(company)).thenReturn(indexRequest);
         when(mockAlphabeticalUpsertRequestService.createUpdateRequest(
-            company, indexRequest)).thenReturn(any(UpdateRequest.class));
+            company, indexRequest)).thenReturn(updateRequest);
 
         ResponseObject responseObject = upsertCompanyService.upsert(company);
 
@@ -84,7 +86,7 @@ class UpsertCompanyServiceTest {
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(createResponse());
         when(mockAdvancedUpsertRequestService.createUpdateRequest(
-            company, ORDERED_ALPHA_KEY_FIELD, SAME_AS_ALPHA_KEY_FIELD)).thenReturn(any(UpdateRequest.class));
+            company, ORDERED_ALPHA_KEY_FIELD, SAME_AS_ALPHA_KEY_FIELD)).thenReturn(updateRequest);
 
         ResponseObject responseObject = upsertCompanyService.upsertAdvanced(company);
 
@@ -101,7 +103,7 @@ class UpsertCompanyServiceTest {
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(null);
         when(mockAdvancedUpsertRequestService.createUpdateRequest(
-            company, "", "")).thenReturn(any(UpdateRequest.class));
+            company, "", "")).thenReturn(updateRequest);
 
         ResponseObject responseObject = upsertCompanyService.upsertAdvanced(company);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestServiceTest.java
@@ -4,7 +4,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -16,30 +15,24 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.RegisteredOfficeAddressApi;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.AdvancedSearchUpsertRequest;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.service.AlphaKeyService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AdvancedUpsertRequestServiceTest {
 
     @Mock
-    private AlphaKeyService mockAlphaKeyService;
-
-    @Mock
-    private EnvironmentReader mockEnvironmentReader;
-
-    @Mock
     private AdvancedSearchUpsertRequest mockAdvancedSearchUpsertRequest;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @InjectMocks
     private AdvancedUpsertRequestService advancedUpsertRequestService;
@@ -92,7 +85,7 @@ class AdvancedUpsertRequestServiceTest {
 
     @BeforeEach
     void init() {
-        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ADVANCED_SEARCH);
+        when(indices.advanced()).thenReturn(ADVANCED_SEARCH);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/alphabetical/AlphabeticalUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/alphabetical/AlphabeticalUpsertRequestServiceTest.java
@@ -1,28 +1,5 @@
 package uk.gov.companieshouse.search.api.service.upsert.alphabetical;
 
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchUpsertRequest;
-import uk.gov.companieshouse.search.api.exception.UpsertException;
-import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
-import uk.gov.companieshouse.search.api.service.AlphaKeyService;
-import uk.gov.companieshouse.search.api.service.upsert.alphabetical.AlphabeticalUpsertRequestService;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,8 +7,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchUpsertRequest;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
+import uk.gov.companieshouse.search.api.service.AlphaKeyService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlphabeticalUpsertRequestServiceTest {
 
     @InjectMocks
@@ -41,10 +37,10 @@ class AlphabeticalUpsertRequestServiceTest {
     private AlphaKeyService mockAlphaKeyService;
 
     @Mock
-    private EnvironmentReader mockEnvironmentReader;
+    private AlphabeticalSearchUpsertRequest mockAlphabeticalSearchUpsertRequest;
 
     @Mock
-    private AlphabeticalSearchUpsertRequest mockAlphabeticalSearchUpsertRequest;
+    private ConfiguredIndexNamesProvider indices;
 
     private static final String ALPHA_SEARCH = "alpha_search";
 
@@ -67,7 +63,7 @@ class AlphabeticalUpsertRequestServiceTest {
     @BeforeEach
     void init() {
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(createResponse());
-        when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ALPHA_SEARCH);
+        when(indices.alphabetical()).thenReturn(ALPHA_SEARCH);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClien
 import java.io.IOException;
 
 import javax.naming.ServiceUnavailableException;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 public class UpsertDisqualificationServiceTest {
@@ -32,6 +33,8 @@ public class UpsertDisqualificationServiceTest {
     private PrimarySearchRestClientService primarySearchRestClientService;
     @Mock
     private DisqualifiedUpsertRequestService disqualifiedUpsertRequestService;
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
     @InjectMocks
     private UpsertDisqualificationService service;
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
@@ -6,10 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.util.NoSuchElementException;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.NoSuchElementException;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,9 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.convert.ConversionService;
 import uk.gov.companieshouse.api.officer.AppointmentList;
-import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.model.esdatamodel.OfficerSearchDocument;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class OfficersUpsertRequestServiceTest {
@@ -32,11 +31,11 @@ class OfficersUpsertRequestServiceTest {
     private static final String PRIMARY = "primary_search2";
 
     @Mock
-    private EnvironmentReader reader;
-    @Mock
     private ConversionService converter;
     @Mock
     private ObjectMapper mapper;
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
     private OfficersUpsertRequestService service;
     @Mock
     private AppointmentList appointmentList;
@@ -47,12 +46,12 @@ class OfficersUpsertRequestServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new OfficersUpsertRequestService(reader, converter, mapper);
+        service = new OfficersUpsertRequestService(converter, mapper, indices);
     }
 
     @Test
     void serviceCreatesUpdateRequest() throws Exception {
-        when(reader.getMandatoryString(INDEX)).thenReturn(PRIMARY);
+        when(indices.primary()).thenReturn(PRIMARY);
         when(converter.convert(any(), eq(OfficerSearchDocument.class))).thenReturn(officerSearchDocument);
         when(mapper.writeValueAsString(any())).thenReturn(UPDATE_JSON);
 
@@ -67,14 +66,14 @@ class OfficersUpsertRequestServiceTest {
 
     @Test
     void serviceThrowsNoSuchElementException() {
-        when(reader.getMandatoryString(INDEX)).thenReturn(PRIMARY);
+        when(indices.primary()).thenReturn(PRIMARY);
 
         assertThrows(NoSuchElementException.class, () -> service.createUpdateRequest(appointmentList, OFFICER_ID));
     }
 
     @Test
     void serviceCatchesIOException() throws Exception {
-        when(reader.getMandatoryString(INDEX)).thenReturn(PRIMARY);
+        when(indices.primary()).thenReturn(PRIMARY);
         when(converter.convert(any(), eq(OfficerSearchDocument.class))).thenReturn(officerSearchDocument);
         when(mapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/UpsertOfficersServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/UpsertOfficersServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.search.api.exception.UpsertException;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
 import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
 import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClientService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
 class UpsertOfficersServiceTest {
@@ -35,6 +36,8 @@ class UpsertOfficersServiceTest {
     private AppointmentList appointmentList;
     @Mock
     private UpdateRequest request;
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
 
     @Test
     void officerIsUpsertedCorrectly() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/search/api/util/ConfiguredIndexNamesProviderTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/util/ConfiguredIndexNamesProviderTest.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.search.api.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+
+@ExtendWith(MockitoExtension.class)
+class ConfiguredIndexNamesProviderTest {
+
+    @InjectMocks
+    private ConfiguredIndexNamesProvider indices;
+
+    @Mock
+    private EnvironmentReader environment;
+
+    @Test
+    @DisplayName("Alphabetical index name got from ALPHABETICAL_SEARCH_INDEX environment variable")
+    void alphabeticalGetsCorrectIndexName() {
+        assertExpectedIndexNameGot(() -> indices.alphabetical(), "ALPHABETICAL_SEARCH_INDEX");
+    }
+
+    @Test
+    @DisplayName("Dissolved index name got from DISSOLVED_SEARCH_INDEX environment variable")
+    void dissolvedGetsCorrectIndexName() {
+        assertExpectedIndexNameGot(() -> indices.dissolved(), "DISSOLVED_SEARCH_INDEX");
+    }
+
+    @Test
+    @DisplayName("Advanced index name got from ADVANCED_SEARCH_INDEX environment variable")
+    void advancedGetsCorrectIndexName() {
+        assertExpectedIndexNameGot(() -> indices.advanced(), "ADVANCED_SEARCH_INDEX");
+    }
+
+    @Test
+    @DisplayName("Primary index name got from PRIMARY_SEARCH_INDEX environment variable")
+    void primaryGetsCorrectIndexName() {
+        assertExpectedIndexNameGot(() -> indices.primary(), "PRIMARY_SEARCH_INDEX");
+    }
+
+    interface StringValueProvider {
+        String getValue();
+    }
+
+    void assertExpectedIndexNameGot(
+        final StringValueProvider provider,
+        final String indexEnvironmentVariableName) {
+
+        // Given
+        when(environment.getMandatoryString(indexEnvironmentVariableName)).thenReturn("index name");
+
+        // When and then
+        assertThat(provider.getValue(), is("index name"));
+    }
+}


### PR DESCRIPTION
* This PR changes the API so that it logs the names of the indices it is actually updating as determined by its configuration.
* Testing in Tilt, prior to these changes, we would see the alphabetical index name logged as `index_name: alphabetical_search_index` and the advanced index name logged as `index_name: advanced_search_index`.
* With these changes, we see the names of the indices as configured and updated by the API, i.e., as `index_name: docker_alpha_search` and `index_name: advanced_search_subtypes_2`.