### PR TITLE
BI-13589 - Add a delete Endpoint to alphabetical in search API

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,10 +4,9 @@ weight: 902
 routes:
   1: ^/alphabetical-search/companies
   2: ^/alphabetical-search/companies/*
-  3: ^/alphabetical-search/companies/delete/*
-  4: ^/dissolved-search/companies
-  5: ^/advanced-search/companies
-  6: ^/disqualified-search/disqualified-officers
-  7: ^/disqualified-search/delete
-  8: ^/officers-search/officers
-  9: ^/search/healthcheck
+  3: ^/dissolved-search/companies
+  4: ^/advanced-search/companies
+  5: ^/disqualified-search/disqualified-officers
+  6: ^/disqualified-search/delete
+  7: ^/officers-search/officers
+  8: ^/search/healthcheck

--- a/routes.yaml
+++ b/routes.yaml
@@ -4,9 +4,10 @@ weight: 902
 routes:
   1: ^/alphabetical-search/companies
   2: ^/alphabetical-search/companies/*
-  3: ^/dissolved-search/companies
-  4: ^/advanced-search/companies
-  5: ^/disqualified-search/disqualified-officers
-  6: ^/disqualified-search/delete
-  7: ^/officers-search/officers
-  8: ^/search/healthcheck
+  3: ^/alphabetical-search/companies/delete/*
+  4: ^/dissolved-search/companies
+  5: ^/advanced-search/companies
+  6: ^/disqualified-search/disqualified-officers
+  7: ^/disqualified-search/delete
+  8: ^/officers-search/officers
+  9: ^/search/healthcheck

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
@@ -6,7 +6,16 @@ import java.util.Map;
 import javax.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -109,7 +118,7 @@ public class AlphabeticalSearchController {
         return apiToResponseMapper.map(responseObject);
     }
 
-    @DeleteMapping("/delete/{company_number}")
+    @DeleteMapping("/{company_number}")
     public ResponseEntity<Object> deleteCompany(@PathVariable("company_number") String companyNumber) {
         Map<String, Object> logMap = LoggingUtils.setUpAlphabeticalSearchDeleteLogging(companyNumber, indices);
         getLogger().info("Attempting to delete a company from alphabetical search index", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -151,4 +151,12 @@ public class LoggingUtils {
                 .officerId(officerId)
                 .indexName(indices.primary()).build().getLogMap();
     }
+
+    public static Map<String, Object> setUpAlphabeticalSearchDeleteLogging(
+            String companyName,
+            ConfiguredIndexNamesProvider indices) {
+        return new DataMap.Builder()
+                .companyName(companyName)
+                .indexName(indices.alphabetical()).build().getLogMap();
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteService.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.search.api.service.delete.alphabetical;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
+
+import java.io.IOException;
+import java.util.Map;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+
+import static uk.gov.companieshouse.search.api.logging.LoggingUtils.getLogger;
+
+@Service
+public class AlphabeticalSearchDeleteService {
+
+    private final AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
+
+    private final ConfiguredIndexNamesProvider indices;
+
+    public AlphabeticalSearchDeleteService(AlphabeticalSearchRestClientService alphabeticalSearchRestClientService,
+                                           ConfiguredIndexNamesProvider indices) {
+        this.alphabeticalSearchRestClientService = alphabeticalSearchRestClientService;
+        this.indices = indices;
+    }
+
+    public ResponseObject deleteCompany(String companyNumber) {
+
+        Map<String, Object> logMap =
+                LoggingUtils.setUpAlphabeticalSearchDeleteLogging(companyNumber, indices);
+
+        DeleteRequest deleteRequest = new DeleteRequest(indices.alphabetical(), companyNumber);
+
+        DeleteResponse response;
+        try {
+            response = alphabeticalSearchRestClientService.delete(deleteRequest);
+        } catch (IOException e) {
+            getLogger().error(String.format("IOException encountered when deleting [%s] from the alphabetical search index",
+                    companyNumber), logMap);
+            return new ResponseObject(ResponseStatus.SERVICE_UNAVAILABLE);
+        } catch (ElasticsearchException e) {
+            return new ResponseObject(ResponseStatus.DELETE_REQUEST_ERROR);
+        }
+
+        if (response.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+            getLogger().error(String.format("Document with id: [%s] not found in alphabetical search index",
+                    companyNumber), logMap);
+            return new ResponseObject(ResponseStatus.DELETE_NOT_FOUND);
+        } else {
+            getLogger().info(String.format("Successfully deleted [%s] from alphabetical search index",
+                    companyNumber), logMap);
+            return new ResponseObject(ResponseStatus.DOCUMENT_DELETED);
+        }
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.search.api.service.rest.impl;
 
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -30,5 +32,9 @@ public class AlphabeticalSearchRestClientService implements RestClientService {
     @Override
     public UpdateResponse upsert(UpdateRequest updateRequest) throws IOException {
         return alphabeticalClient.update(updateRequest, RequestOptions.DEFAULT);
+    }
+
+    public DeleteResponse delete(DeleteRequest deleteRequest) throws IOException {
+        return alphabeticalClient.delete(deleteRequest, DEFAULT);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
@@ -3,15 +3,23 @@ package uk.gov.companieshouse.search.api.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.*;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SIZE_PARAMETER_ERROR;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPDATE_REQUEST_ERROR;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPSERT_ERROR;
 import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_DELETED;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_NOT_FOUND;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_UPSERTED;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DELETE_NOT_FOUND;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -276,7 +284,7 @@ class AlphabeticalSearchControllerTest {
 
     @Test
     @DisplayName("Test delete returns a HTTP 404 Response if the company number is not presented")
-    void testDeleteWithEmptyCompanyNumberReturnsNotFound() {
+    void testDeleteWithMissingCompanyNumberReturnsNotFound() {
         when(mockApiToResponseMapper.map(any()))
                 .thenReturn(ResponseEntity.status(NOT_FOUND).build());
 
@@ -287,7 +295,21 @@ class AlphabeticalSearchControllerTest {
         assertNotNull(responseEntity);
         assertEquals(NOT_FOUND, responseEntity.getStatusCode());
     }
-    
+
+    @Test
+    @DisplayName("Test delete returns a HTTP 400 BAD REQUEST Response if the company number is missing")
+    void testDeleteWithEmptyCompanyNumberReturnsNotFound() {
+
+        when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
+                .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
+
+        ResponseEntity<?> responseEntity = alphabeticalSearchController.deleteCompany(null);
+
+        assertEquals(DELETE_NOT_FOUND, responseObjectCaptor.getValue().getStatus());
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+    }
+
     private CompanyProfileApi createCompany() {
         CompanyProfileApi company = new CompanyProfileApi();
         company.setType("company type");

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
@@ -2,20 +2,16 @@ package uk.gov.companieshouse.search.api.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_UPSERTED;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_FOUND;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SEARCH_NOT_FOUND;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SIZE_PARAMETER_ERROR;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPDATE_REQUEST_ERROR;
-import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.UPSERT_ERROR;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.*;
+import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.DOCUMENT_DELETED;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +32,7 @@ import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 import uk.gov.companieshouse.search.api.model.esdatamodel.Company;
 import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.service.delete.alphabetical.AlphabeticalSearchDeleteService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
@@ -63,6 +60,9 @@ class AlphabeticalSearchControllerTest {
 
     @InjectMocks
     private AlphabeticalSearchController alphabeticalSearchController;
+
+    @Mock
+    private AlphabeticalSearchDeleteService alphabeticalSearchDeleteService;
 
     private static final String REQUEST_ID = "requestID";
     private static final String COMPANY_NAME = "test name";
@@ -253,6 +253,39 @@ class AlphabeticalSearchControllerTest {
         assertEquals(SIZE_PARAMETER_ERROR, responseObjectCaptor.getValue().getStatus());
         assertNotNull(responseEntity);
         assertEquals(UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test delete returns a HTTP 200 Ok Response if company is found in the index")
+    void testDeleteWithCompanyNumberReturnsOkRequest() {
+
+        String companyNumber = "00002400";
+
+        when(alphabeticalSearchDeleteService.deleteCompany(companyNumber))
+                .thenReturn(new ResponseObject(DOCUMENT_DELETED));
+        when(mockApiToResponseMapper.map(any()))
+                .thenReturn(ResponseEntity.status(OK).build());
+
+        ResponseEntity<?> responseEntity = alphabeticalSearchController.deleteCompany(companyNumber);
+
+        verify(mockApiToResponseMapper).map(responseObjectCaptor.capture());
+        assertEquals(DOCUMENT_DELETED, responseObjectCaptor.getValue().getStatus());
+        assertNotNull(responseEntity);
+        assertEquals(OK, responseEntity.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test delete returns a HTTP 404 Response if the company number is not presented")
+    void testDeleteWithEmptyCompanyNumberReturnsNotFound() {
+        when(mockApiToResponseMapper.map(any()))
+                .thenReturn(ResponseEntity.status(NOT_FOUND).build());
+
+        ResponseEntity<?> responseEntity = alphabeticalSearchController.deleteCompany("");
+
+        verify(mockApiToResponseMapper).map(responseObjectCaptor.capture());
+        assertEquals(DELETE_NOT_FOUND, responseObjectCaptor.getValue().getStatus());
+        assertNotNull(responseEntity);
+        assertEquals(NOT_FOUND, responseEntity.getStatusCode());
     }
     
     private CompanyProfileApi createCompany() {

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteServiceTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.search.api.service.delete.alphabetical;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.index.shard.ShardId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AlphabeticalSearchDeleteServiceTest {
+
+    private static final String INDEX = "alphabetical_search";
+
+    private static final String TEST_COMPANY_NUMBER = "00002500";
+
+    @Mock
+    AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
+
+    @Mock
+    private ConfiguredIndexNamesProvider indices;
+
+    @InjectMocks
+    AlphabeticalSearchDeleteService service;
+
+    @Test
+    void deletesCompany() throws IOException {
+
+        when(indices.alphabetical()).thenReturn("alphabetical_search");
+        DeleteResponse deleteResponse = new DeleteResponse(
+                new ShardId(INDEX, INDEX, 1), INDEX, "1", 1, 1, 1, true);
+
+        when(alphabeticalSearchRestClientService.delete(any(DeleteRequest.class))).thenReturn(deleteResponse);
+
+        ResponseObject response = service.deleteCompany(TEST_COMPANY_NUMBER);
+
+        assertEquals(ResponseStatus.DOCUMENT_DELETED, response.getStatus());
+
+    }
+
+    @Test
+    void returnsDeleteNotFoundWhenCompanyDoesNotExist() throws IOException {
+        DeleteResponse deleteResponse = new DeleteResponse(
+                new ShardId(INDEX, INDEX, 1), INDEX, "1", 1, 1, 1, false);
+
+        when(alphabeticalSearchRestClientService.delete(any(DeleteRequest.class))).thenReturn(deleteResponse);
+
+        ResponseObject response = service.deleteCompany(TEST_COMPANY_NUMBER);
+
+        assertEquals(ResponseStatus.DELETE_NOT_FOUND, response.getStatus());
+    }
+
+    @Test
+    void returnsServiceUnavailableOnIOException() throws IOException {
+
+        when(alphabeticalSearchRestClientService.delete(any(DeleteRequest.class))).thenThrow(IOException.class);
+
+        ResponseObject response = service.deleteCompany(TEST_COMPANY_NUMBER);
+
+        assertEquals(ResponseStatus.SERVICE_UNAVAILABLE, response.getStatus());
+    }
+
+    @Test
+    void returnsUpdateErrorOnElasticSearchException() throws Exception {
+
+        when(alphabeticalSearchRestClientService.delete(any(DeleteRequest.class))).thenThrow(ElasticsearchException.class);
+
+        ResponseObject response = service.deleteCompany(TEST_COMPANY_NUMBER);
+
+        assertEquals(ResponseStatus.DELETE_REQUEST_ERROR, response.getStatus());
+    }
+
+}


### PR DESCRIPTION
- Adding delete endpoint to alphabetical search
- Tested locally in Postman - returns 200 OK response
- Tests updated
- Fulfils [BI-13589](https://companieshouse.atlassian.net/browse/BI-13589)

[BI-13589]: https://companieshouse.atlassian.net/browse/BI-13589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ