### PR TITLE
Update api-sdk-java version to include corporate annotation field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <api-sdk-java.version>4.3.30</api-sdk-java.version>
+        <api-sdk-java.version>4.3.40</api-sdk-java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>


### PR DESCRIPTION
Search API is being sent fields that it doesn't know exists i.e `corporate_annotation`. Updating the `api-sdk-java` version will allow these fields to be present and handled when they are sent across.