### PR TITLE
BI-14088: Add ROA null check for advanced search upsert

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchUpsertRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchUpsertRequest.java
@@ -48,6 +48,11 @@ public class AdvancedSearchUpsertRequest {
         String sameAsKey) throws IOException {
 
         RegisteredOfficeAddressApi registeredOfficeAddress = company.getRegisteredOfficeAddress();
+
+        if(registeredOfficeAddress == null){
+            registeredOfficeAddress = new RegisteredOfficeAddressApi();
+        }
+
         Map<String, String> links = company.getLinks();
 
         XContentBuilder jsonBuilder = jsonBuilder().startObject();

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchUpsertRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchUpsertRequestTest.java
@@ -51,6 +51,21 @@ class AdvancedSearchUpsertRequestTest {
         assertNotNull(xContentBuilder);
     }
 
+    @Test
+    @DisplayName("Test build request is successful even when registered office address is null")
+    void testBuildRequestReturnsXContentBuilderWithNullRegisteredOfficeAddress() throws Exception{
+        AdvancedSearchUpsertRequest advancedSearchUpsertRequest = new AdvancedSearchUpsertRequest();
+        CompanyProfileApi companyProfile = createCompany(false);
+        //simulate if registeredOfficeAddress was missing from the payload
+        companyProfile.setRegisteredOfficeAddress(null);
+
+        XContentBuilder xContentBuilder =
+                advancedSearchUpsertRequest.buildRequest(companyProfile, ALPHA_KEY, ALPHA_KEY);
+
+        assertNotNull(xContentBuilder);
+    }
+
+
     private CompanyProfileApi createCompany(final boolean populateRegisteredAddressFields) {
         CompanyProfileApi company = new CompanyProfileApi();
         company.setType(COMPANY_TYPE);


### PR DESCRIPTION
"One of the goals in DataSync was to prevent the storage of empty objects. For example, if there isn’t an address, the system will skip persisting `data.registered_office_address: {}` altogether."

As a result of this change from DataSync, the ROA object in the upsert payload was being omitted all together and causing  a NullPointerException. This is a simple null check which instead uses an empty object to replicate the previous behaviour of `data.registered_office_address: {}`