### PR TITLE
Bi 14089: ROA null check primary upsert

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverter.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverter.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.company.RegisteredOfficeAddress;
 import uk.gov.companieshouse.search.api.model.esdatamodel.CompanySearchItemConverterModel;
 import uk.gov.companieshouse.search.api.model.esdatamodel.CompanySearchAddress;
 import uk.gov.companieshouse.search.api.model.esdatamodel.CompanySearchItem;
@@ -24,7 +25,11 @@ public class CompanySearchItemConverter implements Converter<CompanySearchItemCo
 
     @Override
     public CompanySearchItem convert(CompanySearchItemConverterModel model) {
-        String renderedFullAddress = getROAFullAddressString(model.getRegisteredOfficeAddress());
+        RegisteredOfficeAddress roa = model.getRegisteredOfficeAddress();
+        //if ROA is empty, use an empty object to avoid NullPointerException
+        if (roa == null) roa = new RegisteredOfficeAddress();
+
+        String renderedFullAddress = getROAFullAddressString(roa);
         Pair<String, String> corporateNameEndings = getCorporateNameEndings(model.getCompanyName());
 
         if (!model.isPartialData() && model.getCeasedOn() == null) {
@@ -33,7 +38,7 @@ public class CompanySearchItemConverter implements Converter<CompanySearchItemCo
                     .corporateNameEnding(corporateNameEndings.getRight())
                     .dateOfCreation(model.getDateOfCreation())
                     .fullAddress(renderedFullAddress)
-                    .address(companySearchAddressConverter.convert(model.getRegisteredOfficeAddress(),
+                    .address(companySearchAddressConverter.convert(roa,
                             CompanySearchAddress.class))
                     .companyNumber(model.getCompanyNumber())
                     .externalRegistrationNumber(model.getExternalRegistrationNumber())

--- a/src/test/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverterTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.search.api.mapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -146,6 +147,45 @@ class CompanySearchItemConverterTest {
 
         //then
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void convertWithNullRoa() {
+        // given
+        CompanySearchItemConverterModel model = new CompanySearchItemConverterModel()
+                .partialData(false)
+                .companyName("TEST COMPANY PLC")
+                .dateOfCreation(LocalDate.of(2000, 6, 24))
+                .registeredOfficeAddress(null)
+                .companyNumber("ABCD1234")
+                .externalRegistrationNumber("CDEF3456")
+                .dateOfCessation(LocalDate.of(2024, 6, 24))
+                .sicCodes(Arrays.asList("12345", "23456", "34567"))
+                .companyStatus("active")
+                .alphaKey("TESTCOMPANYS");
+
+        CompanySearchItem expected = CompanySearchItem.Builder.builder()
+                .corporateNameStart("TEST COMPANY")
+                .corporateNameEnding("PLC")
+                .dateOfCreation(LocalDate.of(2000, 6, 24))
+                .fullAddress("")
+                .address(null)
+                .companyNumber("ABCD1234")
+                .externalRegistrationNumber("CDEF3456")
+                .dateOfCessation(LocalDate.of(2024, 6, 24))
+                .sicCodes(Arrays.asList("12345", "23456", "34567"))
+                .companyStatus("active")
+                .sameAsKey("TESTCOMPANY")
+                .wildcardKey("TESTCOMPANYS0")
+                .build();
+
+        // when
+        CompanySearchItem actual = converter.convert(model);
+
+        //then
+        assertEquals(expected, actual);
+        verify(companySearchAddressConverter).convert(
+                new RegisteredOfficeAddress(), CompanySearchAddress.class);
     }
 
     private RegisteredOfficeAddress getROAProperites() {


### PR DESCRIPTION
"One of the goals in DataSync was to prevent the storage of empty objects. For example, if there isn’t an address, the system will skip persisting data.registered_office_address: {} altogether."

As a result of this change from DataSync, the ROA object in the upsert payload was being omitted all together and causing a NullPointerException. This change instead uses a empty RegisteredOfficeAddress object to avoid this NullPointerException so that the Primary upsert request can continue without the ROA.