### PR TITLE
Feature/asm 306 maintain search api ch gov uk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
 
-        <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.3</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.4</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.4</spring-boot-maven-plugin.version>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 
         <spring-boot-dependencies.version>3.5.5</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.5</spring-boot-maven-plugin.version>
+        <!-- version added to resolve CVE-2025-41249 caused by spring-core which is a transitive dependency-->
+        <spring-web.version>6.2.11</spring-web.version>
+        <!-- version added to resolve CVE-2025-41248 caused by spring-security-core which is a transitive dependency-->
+        <spring-security-config.version>6.5.4</spring-security-config.version>
+
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
     </properties>
@@ -87,6 +92,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <version>${spring-web.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -222,6 +228,7 @@
         <dependency>
             <artifactId>spring-security-config</artifactId>
             <groupId>org.springframework.security</groupId>
+            <version>${spring-security-config.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <api-security-java.version>2.0.14</api-security-java.version>
         <private-api-sdk-java.version>4.0.337</private-api-sdk-java.version>
 
+
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <!-- Elastic Search -->
         <elasticsearch.version>7.9.3</elasticsearch.version>
 
@@ -97,6 +99,13 @@
             </exclusions>
         </dependency>
 
+        <!-- added to resolve CVE-2025-48924(5.3) -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
@@ -148,6 +157,19 @@
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- To resolve CVE-2025-48924, excluding commons lang which has no version later than 2.6 -->
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!--To resolve CVE-2023-0833, excluding sonarsource.scanner.api
+                    which has no version later than 2.16.3.1081 -->
+                    <groupId>org.sonarsource.scanner.api</groupId>
+                    <artifactId>sonar-scanner-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-security-java.version>2.0.13</api-security-java.version>
+        <api-security-java.version>2.0.14</api-security-java.version>
         <private-api-sdk-java.version>4.0.337</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
@@ -42,7 +42,6 @@
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
 
         <!-- sonar config -->
-        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
 		<sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
 		<sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
 		<sonar.login></sonar.login>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <api-sdk-java.version>6.4.2</api-sdk-java.version>
+        <api-sdk-java.version>6.4.4</api-sdk-java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
@@ -34,7 +34,7 @@
         <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
 
         <!-- Structured logging -->
-        <structured-logging.version>3.0.37</structured-logging.version>
+        <structured-logging.version>3.0.38</structured-logging.version>
         <log4j.version>2.23.1</log4j.version>
 
         <!-- Maven and Surefire plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             </exclusions>
         </dependency>
 
-        <!-- added to resolve CVE-2025-48924(5.3) -->
+        <!-- added to resolve CVE-2025-48924(5.3) transitive dependency of api-security-java needing latest version  -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -159,7 +159,7 @@
             <version>${sonar-maven-plugin.version}</version>
             <exclusions>
                 <exclusion>
-                    <!-- To resolve CVE-2025-48924, excluding commons lang which has no version later than 2.6 -->
+                    <!-- To resolve CVE-2025-48924, excluding commonslang which has no version later than 2.6 -->
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,10 @@
 
         <spring-boot-dependencies.version>3.5.5</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.5</spring-boot-maven-plugin.version>
-        <!-- version added to resolve CVE-2025-41249 caused by spring-core which is a transitive dependency-->
-        <spring-web.version>6.2.11</spring-web.version>
-        <!-- version added to resolve CVE-2025-41248 caused by spring-security-core which is a transitive dependency-->
-        <spring-security-config.version>6.5.4</spring-security-config.version>
+        <!-- version added to resolve CVE-2025-41249-->
+        <spring-core.version>6.2.11</spring-core.version>
+        <!-- version added to resolve CVE-2025-41248 -->
+        <spring-security-core.version>6.5.4</spring-security-core.version>
 
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
@@ -92,7 +92,18 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${spring-web.version}</version>
+        </dependency>
+        <!-- version added to resolve CVE-2025-41249-->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring-security-core.version}</version>
+        </dependency>
+        <!--Added to resolve CVE-2025-41248-->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -228,7 +239,6 @@
         <dependency>
             <artifactId>spring-security-config</artifactId>
             <groupId>org.springframework.security</groupId>
-            <version>${spring-security-config.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
         <environment-reader-library.version>3.0.1</environment-reader-library.version>
 
-        <spring-boot-dependencies.version>3.4.5</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.5</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.3</spring-boot-maven-plugin.version>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
 
-        <spring-boot-dependencies.version>3.5.4</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.4</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.5</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.5</spring-boot-maven-plugin.version>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 
     <properties>
         <java.version>21</java.version>
-        <api-sdk-java.version>6.2.9</api-sdk-java.version>
+        <api-sdk-java.version>6.4.2</api-sdk-java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-security-java.version>2.0.8</api-security-java.version>
-        <private-api-sdk-java.version>4.0.291</private-api-sdk-java.version>
+        <api-security-java.version>2.0.11</api-security-java.version>
+        <private-api-sdk-java.version>4.0.337</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.9.3</elasticsearch.version>
@@ -34,7 +34,7 @@
         <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
 
         <!-- Structured logging -->
-        <structured-logging.version>3.0.31</structured-logging.version>
+        <structured-logging.version>3.0.37</structured-logging.version>
         <log4j.version>2.23.1</log4j.version>
 
         <!-- Maven and Surefire plugins -->
@@ -60,7 +60,7 @@
         <artifactoryResolveSnapshotRepo>libs-snapshot-local</artifactoryResolveSnapshotRepo>
         <artifactoryResolveReleaseRepo>virtual-release</artifactoryResolveReleaseRepo>
 
-        <environment-reader-library.version>3.0.1</environment-reader-library.version>
+        <environment-reader-library.version>3.0.3</environment-reader-library.version>
 
         <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.3</spring-boot-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-security-java.version>2.0.11</api-security-java.version>
+        <api-security-java.version>2.0.13</api-security-java.version>
         <private-api-sdk-java.version>4.0.337</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
@@ -42,6 +42,7 @@
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
 
         <!-- sonar config -->
+        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
 		<sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
 		<sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
 		<sonar.login></sonar.login>

--- a/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/SearchApiApplication.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.search.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -13,11 +12,14 @@ public class SearchApiApplication implements WebMvcConfigurer {
 
     public static final String APPLICATION_NAME_SPACE = "search.api.ch.gov.uk";
 
-    @Autowired
     private UserAuthorisationInterceptor authorisationInterceptor;
 
-    @Autowired
     private LoggingInterceptor loggingInterceptor;
+
+    public SearchApiApplication(UserAuthorisationInterceptor authorisationInterceptor, LoggingInterceptor loggingInterceptor) {
+        this.authorisationInterceptor = authorisationInterceptor;
+        this.loggingInterceptor = loggingInterceptor;
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SearchApiApplication.class, args);

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -75,7 +74,6 @@ public class AdvancedSearchController {
     }
 
     @GetMapping("/companies")
-    @ResponseBody
     public ResponseEntity<Object> search(@RequestParam(name = START_INDEX_QUERY_PARAM, required = false) Integer startIndex,
                                          @RequestParam(name = COMPANY_NAME_QUERY_PARAM, required = false) String companyName,
                                          @RequestParam(name = LOCATION_QUERY_PARAM, required = false) String location,

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchController.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,7 +62,6 @@ public class AlphabeticalSearchController {
     }
 
     @GetMapping("/companies")
-    @ResponseBody
     public ResponseEntity<Object> searchByCorporateName(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
                                                    @RequestParam(name = SEARCH_BEFORE_PARAM, required = false) String searchBefore,
                                                    @RequestParam(name = SEARCH_AFTER_PARAM, required = false) String searchAfter,

--- a/src/main/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/DissolvedSearchController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -59,7 +58,6 @@ public class DissolvedSearchController {
     }
 
     @GetMapping("/companies")
-    @ResponseBody
     public ResponseEntity<Object> searchCompanies(@RequestParam(name = COMPANY_NAME_QUERY_PARAM) String companyName,
             @RequestParam(name = SEARCH_TYPE_QUERY_PARAM) String searchType,
             @RequestParam(name = SEARCH_BEFORE_PARAM, required = false) String searchBefore,

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
@@ -9,7 +9,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -17,7 +16,6 @@ import uk.gov.companieshouse.search.api.logging.LoggingUtils;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
 
 public abstract class AbstractSearchRequest {
-    
     abstract String getIndex();
     
     abstract String getResultsSize();
@@ -25,12 +23,14 @@ public abstract class AbstractSearchRequest {
     abstract RestClientService getRestClientService();
     
     abstract AbstractSearchQuery getSearchQuery();
-    
-    @Autowired
+
     private EnvironmentReader environmentReader;
     
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
-    
+
+    protected AbstractSearchRequest(EnvironmentReader environmentReader) {
+        this.environmentReader = environmentReader;
+    }
 
     public SearchHits getBestMatchResponse(String orderedAlphakey, String requestId) throws IOException {
         Map<String, Object> logMap = new DataMap.Builder()

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequests.java
@@ -3,21 +3,31 @@ package uk.gov.companieshouse.search.api.elasticsearch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
 import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 
 @Component
 public class AlphabeticalSearchRequests extends AbstractSearchRequest {
 
-    @Autowired
     private AlphabeticalSearchRestClientService searchRestClient;
 
-    @Autowired
     private AlphabeticalSearchQueries alphabeticalSearchQueries;
 
     private static final String INDEX = "ALPHABETICAL_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "ALPHABETICAL_SEARCH_RESULT_MAX";
-    
+
+    @Autowired
+    public AlphabeticalSearchRequests(
+        EnvironmentReader environmentReader,
+        AlphabeticalSearchRestClientService searchRestClient,
+        AlphabeticalSearchQueries alphabeticalSearchQueries
+    ) {
+        super(environmentReader);
+        this.searchRestClient = searchRestClient;
+        this.alphabeticalSearchQueries = alphabeticalSearchQueries;
+    }
+
     @Override
     String getIndex() {
         return INDEX;

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -19,19 +19,26 @@ import java.util.Map;
 @Component
 public class DissolvedSearchRequests extends AbstractSearchRequest {
 
-    @Autowired
     private DissolvedSearchRestClientService searchRestClient;
 
-    @Autowired
     private DissolvedSearchQueries searchQueries;
 
-    @Autowired
     private EnvironmentReader environmentReader;
 
     private static final String INDEX = "DISSOLVED_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "DISSOLVED_SEARCH_RESULT_MAX";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
 
+    @Autowired
+    public DissolvedSearchRequests(
+            EnvironmentReader environmentReader,
+            DissolvedSearchRestClientService searchRestClient,
+            DissolvedSearchQueries searchQueries
+    ) {
+        super(environmentReader);
+        this.searchRestClient = searchRestClient;
+        this.searchQueries = searchQueries;
+    }
     @Override
     String getIndex() {
         return INDEX;

--- a/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/logging/LoggingUtils.java
@@ -2,11 +2,9 @@ package uk.gov.companieshouse.search.api.logging;
 
 import static uk.gov.companieshouse.search.api.SearchApiApplication.APPLICATION_NAME_SPACE;
 
-import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import uk.gov.companieshouse.api.disqualification.Item;
@@ -80,7 +78,6 @@ public class LoggingUtils {
         String requestId,
         ConfiguredIndexNamesProvider indices) {
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
         Date incorporatedFromDate = null;
         Date incorporatedToDate = null;
         Date dissolvedFromDate = null;

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/AdvancedQueryParamMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/AdvancedQueryParamMapper.java
@@ -9,7 +9,6 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.exception.DateFormatException;
@@ -78,11 +77,14 @@ public class AdvancedQueryParamMapper {
         "private-fund-limited-partnership"
     );
 
-    @Autowired
     private EnvironmentReader environmentReader;
 
     private static final String ADVANCED_SEARCH_DEFAULT_SIZE = "ADVANCED_SEARCH_DEFAULT_SIZE";
     private static final String ADVANCED_SEARCH_MAX_SIZE = "ADVANCED_SEARCH_MAX_SIZE";
+
+    public AdvancedQueryParamMapper(EnvironmentReader environmentReader) {
+        this.environmentReader = environmentReader;
+    }
 
     public AdvancedSearchQueryParams mapAdvancedQueryParameters(Integer startIndex,
                                                                 String companyNameIncludes,

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/ApiToResponseMapper.java
@@ -26,16 +26,11 @@ public class ApiToResponseMapper {
     public ResponseEntity<Object> map(ResponseObject responseObject) {
 
         switch(responseObject.getStatus()) {
-            case SEARCH_FOUND:
-            case DOCUMENT_UPSERTED:
-            case DOCUMENT_DELETED:
+            case SEARCH_FOUND, DOCUMENT_UPSERTED, DOCUMENT_DELETED:
                 return ResponseEntity.status(OK).body(responseObject.getData());
-            case SEARCH_NOT_FOUND:
-            case DELETE_NOT_FOUND:
+            case SEARCH_NOT_FOUND, DELETE_NOT_FOUND:
                 return ResponseEntity.status(NOT_FOUND).build();
-            case UPDATE_REQUEST_ERROR:
-            case UPSERT_ERROR:
-            case DELETE_REQUEST_ERROR:
+            case UPDATE_REQUEST_ERROR, UPSERT_ERROR, DELETE_REQUEST_ERROR:
                 return ResponseEntity.status(BAD_REQUEST).build();
             case DATE_FORMAT_ERROR:
                 return ResponseEntity.status(BAD_REQUEST)

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchDocumentConverter.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchDocumentConverter.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.search.api.mapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
@@ -61,7 +60,7 @@ public class CompanySearchDocumentConverter implements Converter<Data, CompanySe
                                     .dateOfCreation(data.getDateOfCreation())
                                     .registeredOfficeAddress(data.getRegisteredOfficeAddress()),
                             CompanySearchItem.class))
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         return CompanySearchDocument.Builder.builder()

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverter.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/CompanySearchItemConverter.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.search.api.mapper;
 import static uk.gov.companieshouse.search.api.util.AddressUtils.getROAFullAddressString;
 import static uk.gov.companieshouse.search.api.util.OfficerNameUtils.getCorporateNameEndings;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;

--- a/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseObject.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/response/ResponseObject.java
@@ -3,17 +3,16 @@ package uk.gov.companieshouse.search.api.model.response;
 import com.google.gson.Gson;
 import uk.gov.companieshouse.search.api.model.SearchResults;
 
-public class ResponseObject {
+public class ResponseObject<T> {
 
     private ResponseStatus status;
-
-    private SearchResults searchResults;
+    private SearchResults<T> searchResults;
 
     public ResponseObject(ResponseStatus status) {
         this.status = status;
     }
 
-    public ResponseObject(ResponseStatus status, SearchResults searchResults) {
+    public ResponseObject(ResponseStatus status, SearchResults<T> searchResults) {
         this.status = status;
         this.searchResults = searchResults;
     }
@@ -26,11 +25,11 @@ public class ResponseObject {
         this.status = status;
     }
 
-    public SearchResults getData() {
+    public SearchResults<T> getData() {
         return searchResults;
     }
 
-    public void setData(SearchResults searchResults) {
+    public void setData(SearchResults<T> searchResults) {
         this.searchResults = searchResults;
     }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/AlphaKeyService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/AlphaKeyService.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.search.api.service;
 
 import java.net.URI;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -15,13 +14,16 @@ import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 @Service
 public class AlphaKeyService {
 
-    @Autowired
     private RestTemplate restTemplate;
 
-    @Autowired
     private EnvironmentReader environmentReader;
 
     private static final String ALPHAKEY_SERVICE_URL = "ALPHAKEY_SERVICE_URL";
+
+    public AlphaKeyService(RestTemplate restTemplate, EnvironmentReader environmentReader) {
+        this.restTemplate = restTemplate;
+        this.environmentReader = environmentReader;
+    }
 
     public AlphaKeyResponse getAlphaKeyForCorporateName(String corporateName) {
         corporateName = corporateName.replace("&", "AND");

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
@@ -19,11 +19,11 @@ import java.io.IOException;
 @Service
 public class AdvancedSearchRestClientService implements RestClientService {
 
-
-    @Qualifier("advancedRestClient")
     private RestHighLevelClient advancedRestClient;
 
-    public AdvancedSearchRestClientService(RestHighLevelClient advancedRestClient) {
+    public AdvancedSearchRestClientService(
+            @Qualifier("advancedRestClient") RestHighLevelClient advancedRestClient
+    ) {
         this.advancedRestClient = advancedRestClient;
     }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 public class AdvancedSearchRestClientService implements RestClientService {
 
     @Autowired
-    @Qualifier("advancedClient")
+    @Qualifier("advancedRestClient")
     private RestHighLevelClient advancedClient;
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AdvancedSearchRestClientService.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
@@ -20,21 +19,25 @@ import java.io.IOException;
 @Service
 public class AdvancedSearchRestClientService implements RestClientService {
 
-    @Autowired
+
     @Qualifier("advancedRestClient")
-    private RestHighLevelClient advancedClient;
+    private RestHighLevelClient advancedRestClient;
+
+    public AdvancedSearchRestClientService(RestHighLevelClient advancedRestClient) {
+        this.advancedRestClient = advancedRestClient;
+    }
 
     @Override
     public SearchResponse search(SearchRequest searchRequest) throws IOException {
-        return advancedClient.search(searchRequest, DEFAULT);
+        return advancedRestClient.search(searchRequest, DEFAULT);
     }
 
     @Override
     public UpdateResponse upsert(UpdateRequest updateRequest) throws IOException {
-        return advancedClient.update(updateRequest, RequestOptions.DEFAULT);
+        return advancedRestClient.update(updateRequest, RequestOptions.DEFAULT);
     }
 
     public DeleteResponse delete(DeleteRequest deleteRequest) throws IOException {
-        return advancedClient.delete(deleteRequest, DEFAULT);
+        return advancedRestClient.delete(deleteRequest, DEFAULT);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
@@ -21,7 +21,7 @@ import static org.elasticsearch.client.RequestOptions.DEFAULT;
 public class AlphabeticalSearchRestClientService implements RestClientService {
 
     @Autowired
-    @Qualifier("alphabeticalClient")
+    @Qualifier("alphabeticalRestClient")
     private RestHighLevelClient alphabeticalClient;
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
@@ -20,9 +20,12 @@ import static org.elasticsearch.client.RequestOptions.DEFAULT;
 @Service
 public class AlphabeticalSearchRestClientService implements RestClientService {
 
-    @Autowired
     @Qualifier("alphabeticalRestClient")
     private RestHighLevelClient alphabeticalClient;
+
+    public AlphabeticalSearchRestClientService(RestHighLevelClient alphabeticalClient) {
+        this.alphabeticalClient = alphabeticalClient;
+    }
 
     @Override
     public SearchResponse search(SearchRequest searchRequest) throws IOException {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/AlphabeticalSearchRestClientService.java
@@ -8,7 +8,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.search.api.service.rest.RestClientService;
@@ -20,10 +19,11 @@ import static org.elasticsearch.client.RequestOptions.DEFAULT;
 @Service
 public class AlphabeticalSearchRestClientService implements RestClientService {
 
-    @Qualifier("alphabeticalRestClient")
     private RestHighLevelClient alphabeticalClient;
 
-    public AlphabeticalSearchRestClientService(RestHighLevelClient alphabeticalClient) {
+    public AlphabeticalSearchRestClientService(
+            @Qualifier("alphabeticalRestClient") RestHighLevelClient alphabeticalClient
+    ) {
         this.alphabeticalClient = alphabeticalClient;
     }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DissolvedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DissolvedSearchRestClientService.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import org.springframework.stereotype.Service;
@@ -18,10 +17,14 @@ import uk.gov.companieshouse.search.api.service.rest.RestClientService;
 
 @Service
 public class DissolvedSearchRestClientService implements RestClientService {
-
-    @Autowired
-    @Qualifier("dissolvedRestClient")
+    
     private RestHighLevelClient dissolvedClient;
+
+    public DissolvedSearchRestClientService(
+            @Qualifier("dissolvedRestClient") RestHighLevelClient dissolvedClient
+    ) {
+        this.dissolvedClient = dissolvedClient;
+    }
 
     @Override
     public SearchResponse search(SearchRequest searchRequest) throws IOException {

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DissolvedSearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/DissolvedSearchRestClientService.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.search.api.service.rest.RestClientService;
 public class DissolvedSearchRestClientService implements RestClientService {
 
     @Autowired
-    @Qualifier("dissolvedClient")
+    @Qualifier("dissolvedRestClient")
     private RestHighLevelClient dissolvedClient;
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/PrimarySearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/PrimarySearchRestClientService.java
@@ -20,7 +20,9 @@ public class PrimarySearchRestClientService implements RestClientService {
 
     private final RestHighLevelClient primaryClient;
 
-    public PrimarySearchRestClientService(@Qualifier("primaryRestClient") RestHighLevelClient primaryClient) {
+    public PrimarySearchRestClientService(
+            @Qualifier("primaryRestClient") RestHighLevelClient primaryClient
+    ) {
         this.primaryClient = primaryClient;
     }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/PrimarySearchRestClientService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/rest/impl/PrimarySearchRestClientService.java
@@ -20,7 +20,7 @@ public class PrimarySearchRestClientService implements RestClientService {
 
     private final RestHighLevelClient primaryClient;
 
-    public PrimarySearchRestClientService(@Qualifier("primaryClient") RestHighLevelClient primaryClient) {
+    public PrimarySearchRestClientService(@Qualifier("primaryRestClient") RestHighLevelClient primaryClient) {
         this.primaryClient = primaryClient;
     }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/SearchRequestUtils.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/SearchRequestUtils.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.search.api.service.search;
 
 import org.elasticsearch.search.SearchHit;
-import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.exception.SizeException;
 
@@ -9,10 +8,13 @@ import java.util.Map;
 
 public class SearchRequestUtils {
 
-    @Autowired
     private EnvironmentReader environmentReader;
 
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
+
+    public SearchRequestUtils(EnvironmentReader environmentReader) {
+        this.environmentReader = environmentReader;
+    }
 
     public static String getOrderedAlphaKeyWithId(SearchHit hit) {
         Map<String, Object> sourceAsMap = hit.getSourceAsMap();

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.springframework.stereotype.Service;
@@ -141,17 +140,12 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
     }
 
     public SearchHits peelbackSearchRequest(SearchHits hits, String orderedAlphakey, String requestId)
-        throws IOException {
+            throws IOException {
 
         Integer fallbackQueryLimit = environmentReader.getMandatoryInteger(ALPHABETICAL_FALLBACK_QUERY_LIMIT);
 
         for (int i = 0; i < orderedAlphakey.length(); i++) {
-
-            long totalHits = Optional.ofNullable(hits.getTotalHits())
-                    .map(th -> th.value)
-                    .orElse(0L);
-
-            if (totalHits > 0 || i == fallbackQueryLimit) {
+            if (hits.getTotalHits() != null && hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.springframework.stereotype.Service;
@@ -148,7 +149,11 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
 
         for (int i = 0; i < orderedAlphakey.length(); i++) {
 
-            if (hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
+            long totalHits = Optional.ofNullable(hits.getTotalHits())
+                    .map(th -> th.value)
+                    .orElse(0L);
+
+            if (totalHits > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/alphabetical/AlphabeticalSearchRequestService.java
@@ -86,15 +86,13 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
 
         try {
             SearchHits hits = getSearchHits(orderedAlphakey, requestId);
-
-            if (hits.getTotalHits().value == 0) {
+            if (hits.getTotalHits() != null && hits.getTotalHits().value == 0){
                 getLogger().info("A result was not found, reducing search term to find result", logMap);
                 logMap.remove(MESSAGE);
 
                 hits = peelbackSearchRequest(hits, orderedAlphakey, requestId);
             }
-
-            if (hits.getTotalHits().value > 0) {
+            if (hits.getTotalHits() != null && hits.getTotalHits().value > 0) {
                 getLogger().info("A result has been found", logMap);
                 logMap.remove(MESSAGE);
 
@@ -168,11 +166,11 @@ public class AlphabeticalSearchRequestService implements SearchRequestService {
     private SearchHits getSearchHits(String orderedAlphakey, String requestId) throws IOException {
         SearchHits hits = alphabeticalSearchRequests.getBestMatchResponse(orderedAlphakey, requestId);
 
-        if (hits.getTotalHits().value == 0) {
+        if (hits.getTotalHits() != null && hits.getTotalHits().value == 0) {
             hits = alphabeticalSearchRequests.getStartsWithResponse(orderedAlphakey, requestId);
         }
 
-        if (hits.getTotalHits().value == 0) {
+        if (hits.getTotalHits() != null && hits.getTotalHits().value == 0) {
             hits = alphabeticalSearchRequests.getCorporateNameStartsWithResponse(orderedAlphakey, requestId);
         }
         return hits;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchIndexService.java
@@ -20,7 +20,6 @@ public class DissolvedSearchIndexService {
     private final DissolvedSearchRequestService dissolvedSearchRequestService;
     private final ConfiguredIndexNamesProvider indices;
 
-    private static final String SEARCHING_FOR_COMPANY_INFO = "searching for company";
     private static final String STANDARD_ERROR_MESSAGE = "An error occurred while trying to search for ";
     private static final String NO_RESULTS_FOUND = "No results were returned while searching for ";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -244,17 +244,13 @@ public class DissolvedSearchRequestService {
     }
 
     public SearchHits peelbackSearchRequest(SearchHits hits, String orderedAlphaKey, String requestId)
-        throws IOException {
+            throws IOException {
 
         Integer fallbackQueryLimit = environmentReader.getMandatoryInteger(DISSOLVED_ALPHABETICAL_FALLBACK_QUERY_LIMIT);
 
         for (int i = 0; i < orderedAlphaKey.length(); i++) {
 
-            long totalHits = Optional.ofNullable(hits.getTotalHits())
-                                    .map(th -> th.value)
-                                    .orElse(0L);
-
-            if (totalHits > 0 || i == fallbackQueryLimit) {
+            if (hits.getTotalHits() != null && hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/search/impl/dissolved/DissolvedSearchRequestService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.springframework.stereotype.Service;
@@ -249,7 +250,11 @@ public class DissolvedSearchRequestService {
 
         for (int i = 0; i < orderedAlphaKey.length(); i++) {
 
-            if (hits.getTotalHits().value > 0 || i == fallbackQueryLimit) {
+            long totalHits = Optional.ofNullable(hits.getTotalHits())
+                                    .map(th -> th.value)
+                                    .orElse(0L);
+
+            if (totalHits > 0 || i == fallbackQueryLimit) {
                 return hits;
             }
 

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
@@ -43,7 +43,7 @@ public class CompanySearchUpsertRequestService {
 
         try {
             String jsonString = mapper.writeValueAsString(documentToBeUpserted);
-            return new UpdateRequest(indices.primary(), TYPE, companyNumber)
+            return new UpdateRequest(indices.primary(), companyNumber)
                     .docAsUpsert(true).doc(jsonString, XContentType.JSON);
         } catch (IOException e) {
             LoggingUtils.getLogger().error("Failed to update a document for company profile" + e.getMessage(), logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
@@ -18,8 +18,6 @@ import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 @Service
 public class CompanySearchUpsertRequestService {
 
-    private static final String TYPE = "primary_search";
-
     private final ConversionService companySearchDocumentConverter;
 
     private final ObjectMapper mapper;

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -52,7 +52,7 @@ public class DisqualifiedUpsertRequestService {
         }
 
         try {
-            UpdateRequest request = new UpdateRequest(indices.primary(), TYPE, officerId)
+            UpdateRequest request = new UpdateRequest(indices.primary(), officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
@@ -42,7 +42,7 @@ public class OfficersUpsertRequestService {
         try {
             String jsonString = mapper.writeValueAsString(documentToBeUpserted);
 
-            return new UpdateRequest(indices.primary(), TYPE, officerId)
+            return new UpdateRequest(indices.primary(), officerId)
                     .docAsUpsert(true).doc(jsonString, XContentType.JSON);
 
         } catch (IOException ex) {

--- a/src/main/java/uk/gov/companieshouse/search/api/util/EricHeaderHelper.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/util/EricHeaderHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.search.api.util;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class EricHeaderHelper {
     public static final String API_KEY_IDENTITY_TYPE        = "key";

--- a/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.environment.EnvironmentReader;
@@ -22,8 +21,6 @@ import static org.mockito.Mockito.when;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ElasticSearchConfigTest {
 
-    @InjectMocks
-    private ElasticSearchConfig elasticSearchConfig;
 
     @Mock
     private EnvironmentReader mockEnvironmentReader;
@@ -36,7 +33,7 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test calling create client returns a rest high level client for alphabetical search")
     void testAlphabeticalRestClient() throws Exception {
-
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_ALPHABETICAL);
 
         RestHighLevelClient restHighLevelClient = elasticSearchConfig.alphabeticalRestClient();
@@ -51,7 +48,7 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test calling create client returns a rest high level client for dissolved search")
     void testDissolvedRestClient() throws Exception {
-
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_DISSOLVED);
 
         RestHighLevelClient restHighLevelClient = elasticSearchConfig.dissolvedRestClient();
@@ -65,7 +62,7 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test calling create client returns a rest high level client for advanced search")
     void testAdvancedRestClient() throws Exception {
-
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_ADVANCED);
 
         RestHighLevelClient restHighLevelClient = elasticSearchConfig.advancedRestClient();
@@ -79,10 +76,10 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test calling create client returns a rest high level client for disqualified search")
     void testDisqualifiedRestClient() throws Exception {
-
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_DISQUALIFIED);
 
-        RestHighLevelClient restHighLevelClient = elasticSearchConfig.primaryClient();
+        RestHighLevelClient restHighLevelClient = elasticSearchConfig.primaryRestClient();
         assertNotNull(restHighLevelClient);
 
         List<Node> nodes = restHighLevelClient.getLowLevelClient().getNodes();
@@ -93,7 +90,7 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test create rest high level client returns object successfully")
     void createRestHighLevelClient() throws Exception {
-
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(ENV_READER_RESULT_ALPHABETICAL);
 
         RestHighLevelClient restHighLevelClient = elasticSearchConfig.createClient(ENV_READER_RESULT_ALPHABETICAL);
@@ -108,6 +105,8 @@ class ElasticSearchConfigTest {
     @Test
     @DisplayName("Test create rest high level client throws endpoint exception when not passed valid url")
     void createRestHighLevelClientThrowsEndpointException() throws Exception {
+        ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
+        when(mockEnvironmentReader.getMandatoryString("test")).thenReturn("http://invalid^url");
 
         assertThrows(EndpointException.class, () ->
                 elasticSearchConfig.createClient("test"));

--- a/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/config/ElasticSearchConfigTest.java
@@ -104,7 +104,7 @@ class ElasticSearchConfigTest {
 
     @Test
     @DisplayName("Test create rest high level client throws endpoint exception when not passed valid url")
-    void createRestHighLevelClientThrowsEndpointException() throws Exception {
+    void createRestHighLevelClientThrowsEndpointException() {
         ElasticSearchConfig elasticSearchConfig = new ElasticSearchConfig(mockEnvironmentReader);
         when(mockEnvironmentReader.getMandatoryString("test")).thenReturn("http://invalid^url");
 

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
@@ -3,17 +3,13 @@ package uk.gov.companieshouse.search.api.controller;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
@@ -42,46 +38,42 @@ class AdvancedSearchControllerCORSTest {
     private static final String ERIC_PRIVILEGES = "*";
     private static final String ERIC_AUTH = "internal-app";
 
-    @MockBean
+    @MockitoBean
     private EnvironmentReader mockEnvironmentReader;
 
-    @MockBean
+    @MockitoBean
     AlphabeticalSearchRequests alphabeticalSearchRequests;
 
-    @MockBean
-    @Qualifier("advancedClient")
-    private RestHighLevelClient advancedClient;
+    @MockitoBean
+    private RestHighLevelClient advancedRestClient;
 
-    @MockBean
-    @Qualifier("alphabeticalClient")
-    private RestHighLevelClient alphabeticalClient;
+    @MockitoBean
+    private RestHighLevelClient alphabeticalRestClient;
 
-    @MockBean
-    @Qualifier("dissolvedClient")
-    private RestHighLevelClient dissolvedClient;
+    @MockitoBean
+    private RestHighLevelClient dissolvedRestClient;
 
-    @MockBean
-    @Qualifier("primaryClient")
-    private RestHighLevelClient primaryClient;
+    @MockitoBean
+    private RestHighLevelClient primaryRestClient;
 
     // Injected services
 
-    @MockBean
+    @MockitoBean
     private AdvancedQueryParamMapper queryParamMapper;
 
-    @MockBean
+    @MockitoBean
     private AdvancedSearchIndexService searchIndexService;
 
-    @MockBean
+    @MockitoBean
     private ApiToResponseMapper apiToResponseMapper;
 
-    @MockBean
+    @MockitoBean
     private UpsertCompanyService upsertCompanyService;
 
-    @MockBean
+    @MockitoBean
     private ConfiguredIndexNamesProvider indices;
 
-    @MockBean
+    @MockitoBean
     private AdvancedSearchDeleteService advancedSearchDeleteService;
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
@@ -24,6 +24,7 @@ import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.service.delete.advanced.AdvancedSearchDeleteService;
 import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
+import uk.gov.companieshouse.search.api.service.rest.impl.DissolvedSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
@@ -38,8 +39,6 @@ class AdvancedSearchControllerCORSTest {
     private static final String X_REQUEST_ID = "123456";
     private static final String ERIC_IDENTITY = "Test-Identity";
     private static final String ERIC_IDENTITY_TYPE = "key";
-    private static final String ERIC_PRIVILEGES = "*";
-    private static final String ERIC_AUTH = "internal-app";
 
     @MockitoBean
     private EnvironmentReader mockEnvironmentReader;
@@ -91,6 +90,9 @@ class AdvancedSearchControllerCORSTest {
 
     @Autowired
     private AdvancedSearchController advancedSearchController;
+
+    @MockitoBean
+    private DissolvedSearchRestClientService dissolvedSearchRestClientService;
 
     @Test
     void optionsAdvancedSearchCORS() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AdvancedSearchControllerCORSTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.search.api.controller;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -21,6 +22,8 @@ import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests
 import uk.gov.companieshouse.search.api.mapper.AdvancedQueryParamMapper;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.service.delete.advanced.AdvancedSearchDeleteService;
+import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClientService;
+import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.search.impl.advanced.AdvancedSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
@@ -45,7 +48,14 @@ class AdvancedSearchControllerCORSTest {
     AlphabeticalSearchRequests alphabeticalSearchRequests;
 
     @MockitoBean
+    @Qualifier("advancedRestClient")
     private RestHighLevelClient advancedRestClient;
+
+    @MockitoBean
+    private AdvancedSearchRestClientService advancedRestClientS;
+
+    @MockitoBean
+    private AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
 
     @MockitoBean
     private RestHighLevelClient alphabeticalRestClient;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
@@ -20,6 +20,8 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.elasticsearch.AlphabeticalSearchRequests;
 import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.service.delete.alphabetical.AlphabeticalSearchDeleteService;
+import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClientService;
+import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
@@ -54,6 +56,12 @@ class AlphabeticalSearchControllerCORSTest {
 
     @MockitoBean
     private RestHighLevelClient primaryRestClient;
+
+    @MockitoBean
+    private AdvancedSearchRestClientService advancedRestClientS;
+
+    @MockitoBean
+    private AlphabeticalSearchRestClientService alphabeticalSearchRestClientService;
 
     // Injected services
 

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
 import uk.gov.companieshouse.search.api.service.delete.alphabetical.AlphabeticalSearchDeleteService;
 import uk.gov.companieshouse.search.api.service.rest.impl.AdvancedSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRestClientService;
+import uk.gov.companieshouse.search.api.service.rest.impl.DissolvedSearchRestClientService;
 import uk.gov.companieshouse.search.api.service.search.impl.alphabetical.AlphabeticalSearchIndexService;
 import uk.gov.companieshouse.search.api.service.upsert.UpsertCompanyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
@@ -36,8 +37,6 @@ class AlphabeticalSearchControllerCORSTest {
     private static final String X_REQUEST_ID = "123456";
     private static final String ERIC_IDENTITY = "Test-Identity";
     private static final String ERIC_IDENTITY_TYPE = "key";
-    private static final String ERIC_PRIVILEGES = "*";
-    private static final String ERIC_AUTH = "internal-app";
 
     @MockitoBean
     private EnvironmentReader mockEnvironmentReader;
@@ -79,6 +78,9 @@ class AlphabeticalSearchControllerCORSTest {
 
     @MockitoBean
     private AlphabeticalSearchDeleteService alphabeticalSearchDeleteService;
+
+    @MockitoBean
+    private DissolvedSearchRestClientService dissolvedSearchRestClientService;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerCORSTest.java
@@ -3,17 +3,13 @@ package uk.gov.companieshouse.search.api.controller;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
@@ -41,43 +37,39 @@ class AlphabeticalSearchControllerCORSTest {
     private static final String ERIC_PRIVILEGES = "*";
     private static final String ERIC_AUTH = "internal-app";
 
-    @MockBean
+    @MockitoBean
     private EnvironmentReader mockEnvironmentReader;
 
-    @MockBean
+    @MockitoBean
     AlphabeticalSearchRequests alphabeticalSearchRequests;
 
-    @MockBean
-    @Qualifier("advancedClient")
-    private RestHighLevelClient advancedClient;
+    @MockitoBean
+    private RestHighLevelClient advancedRestClient;
 
-    @MockBean
-    @Qualifier("alphabeticalClient")
-    private RestHighLevelClient alphabeticalClient;
+    @MockitoBean
+    private RestHighLevelClient alphabeticalRestClient;
 
-    @MockBean
-    @Qualifier("dissolvedClient")
-    private RestHighLevelClient dissolvedClient;
+    @MockitoBean
+    private RestHighLevelClient dissolvedRestClient;
 
-    @MockBean
-    @Qualifier("primaryClient")
-    private RestHighLevelClient primaryClient;
+    @MockitoBean
+    private RestHighLevelClient primaryRestClient;
 
     // Injected services
 
-    @MockBean
+    @MockitoBean
     private AlphabeticalSearchIndexService searchIndexService;
 
-    @MockBean
+    @MockitoBean
     private ApiToResponseMapper apiToResponseMapper;
 
-    @MockBean
+    @MockitoBean
     private UpsertCompanyService upsertCompanyService;
 
-    @MockBean
+    @MockitoBean
     private ConfiguredIndexNamesProvider indices;
 
-    @MockBean
+    @MockitoBean
     private AlphabeticalSearchDeleteService alphabeticalSearchDeleteService;
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -185,45 +188,16 @@ class AlphabeticalSearchControllerTest {
         assertEquals(INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
     }
 
-    @Test
-    @DisplayName("Test upsert returns a HTTP 400 Bad Request if the company number is null")
-    void testUpsertWithNullCompanyNumberReturnsBadRequest() {
-        CompanyProfileApi company = createCompany();
+    @ParameterizedTest(name = "Upsert with companyNumber={0} should return HTTP 400 Bad Request")
+    @NullSource
+    @ValueSource(strings = {"", "1234567890"})
+    void testUpsertWithInvalidProductNumberReturnsBadRequest(String productNumber) {
+        CompanyProfileApi product = createCompany();
 
         when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
                 .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
 
-        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany(null, company);
-
-        assertEquals(UPSERT_ERROR, responseObjectCaptor.getValue().getStatus());
-        assertNotNull(responseEntity);
-        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
-    }
-
-    @Test
-    @DisplayName("Test upsert returns a HTTP 400 Bad Request if the company number does not match the request body")
-    void testUpsertWithDifferentCompanyNumberReturnsBadRequest() {
-        CompanyProfileApi company = createCompany();
-
-        when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
-                .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
-
-        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany("1234567890", company);
-
-        assertEquals(UPSERT_ERROR, responseObjectCaptor.getValue().getStatus());
-        assertNotNull(responseEntity);
-        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
-    }
-
-    @Test
-    @DisplayName("Test upsert returns a HTTP 400 Bad Request if the company number is an empty string")
-    void testUpsertWithEmptyStringCompanyNumberReturnsBadRequest() {
-        CompanyProfileApi company = createCompany();
-
-        when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
-                .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
-
-        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany("", company);
+        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany(productNumber, product);
 
         assertEquals(UPSERT_ERROR, responseObjectCaptor.getValue().getStatus());
         assertNotNull(responseEntity);

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/AlphabeticalSearchControllerTest.java
@@ -191,13 +191,13 @@ class AlphabeticalSearchControllerTest {
     @ParameterizedTest(name = "Upsert with companyNumber={0} should return HTTP 400 Bad Request")
     @NullSource
     @ValueSource(strings = {"", "1234567890"})
-    void testUpsertWithInvalidProductNumberReturnsBadRequest(String productNumber) {
-        CompanyProfileApi product = createCompany();
+    void testUpsertWithInvalidCompanyNumberReturnsBadRequest(String companyNumber) {
+        CompanyProfileApi company = createCompany();
 
         when(mockApiToResponseMapper.map(responseObjectCaptor.capture()))
                 .thenReturn(ResponseEntity.status(BAD_REQUEST).build());
 
-        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany(productNumber, product);
+        ResponseEntity<?> responseEntity = alphabeticalSearchController.upsertCompany(companyNumber, company);
 
         assertEquals(UPSERT_ERROR, responseObjectCaptor.getValue().getStatus());
         assertNotNull(responseEntity);

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/CompanySearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/CompanySearchControllerTest.java
@@ -36,7 +36,7 @@ import static uk.gov.companieshouse.search.api.model.response.ResponseStatus.SER
 
 @ExtendWith(MockitoExtension.class)
 class CompanySearchControllerTest {
-    private final String COMPANY_NUMBER = "12345678";
+    private static final String COMPANY_NUMBER = "12345678";
     @Mock
     private ApiToResponseMapper mockApiToResponseMapper;
 

--- a/src/test/java/uk/gov/companieshouse/search/api/controller/OfficersSearchControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/controller/OfficersSearchControllerTest.java
@@ -30,8 +30,8 @@ import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 @ExtendWith(MockitoExtension.class)
 class OfficersSearchControllerTest {
 
-    private final String OFFICER_ID = "ABCD1234";
-    private final String REQUEST_ID = "DEFG5678";
+    private static final String OFFICER_ID = "ABCD1234";
+    private static final String REQUEST_ID = "DEFG5678";
     @Mock
     private ApiToResponseMapper apiToResponseMapper;
     @Captor

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AdvancedSearchRequestsTest.java
@@ -66,8 +66,7 @@ class AdvancedSearchRequestsTest {
         SearchHits hits = new SearchHits(new SearchHit[]{hit}, totalHits, 10);
         SearchResponseSections searchResponseSections = new SearchResponseSections(hits, null, null, false, null, null, 5);
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(1, 1, 0);
-        SearchResponse searchResponse = new SearchResponse(searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[]{}, clusters);
-        return searchResponse;
+        return new SearchResponse(searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[]{}, clusters);
     }
 
     private AdvancedSearchQueryParams createAdvancedSearchQueryParams() {

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
@@ -125,7 +125,6 @@ class AlphabeticalSearchRequestsTest {
         SearchHits hits = new SearchHits( new SearchHit[] { hit }, totalHits, 10 );
         SearchResponseSections searchResponseSections = new SearchResponseSections( hits, null, null, false, null, null, 5 );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(1, 1, 0);
-        SearchResponse searchResponse = new SearchResponse( searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[] {}, clusters );
-        return searchResponse;
+        return new SearchResponse( searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[] {}, clusters );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DisqualifiedSearchUpsertRequestTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.api.disqualification.Item;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
 import uk.gov.companieshouse.search.api.exception.UpsertException;
 
-public class DisqualifiedSearchUpsertRequestTest {
+class DisqualifiedSearchUpsertRequestTest {
 
     private static final String FORENAME = "forename";
     private static final String SURNAME = "surname";
@@ -39,19 +39,19 @@ public class DisqualifiedSearchUpsertRequestTest {
     }
 
     @Test
-    void missingKindOfficerIsNotTransformedToJSONString() throws Exception {
+    void missingKindOfficerIsNotTransformedToJSONString() {
         assertThrows(UpsertException.class,
             () -> request.buildRequest(createOfficer(false, true, true)));
     }
 
     @Test
-    void missingSelfOfficerIsNotTransformedToJSONString() throws Exception {
+    void missingSelfOfficerIsNotTransformedToJSONString() {
         assertThrows(UpsertException.class,
             () -> request.buildRequest(createOfficer(true, false, true)));
     }
 
     @Test
-    void missingAddressOfficerIsNotTransformedToJSONString() throws Exception {
+    void missingAddressOfficerIsNotTransformedToJSONString() {
         assertThrows(UpsertException.class,
             () -> request.buildRequest(createOfficer(true, true, false)));
     }
@@ -124,9 +124,8 @@ public class DisqualifiedSearchUpsertRequestTest {
     }
 
     private JSONObject createAddress() throws Exception {
-        JSONObject address = new JSONObject()
+        return new JSONObject()
         .put("postcode", "postcode")
         .put("address_line_1", "addressLine1");
-        return address;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -155,7 +155,6 @@ class DissolvedSearchRequestsTest {
         SearchHits hits = new SearchHits( new SearchHit[] { hit }, totalHits, 10 );
         SearchResponseSections searchResponseSections = new SearchResponseSections( hits, null, null, false, null, null, 5 );
         SearchResponse.Clusters clusters = new SearchResponse.Clusters(1, 1, 0);
-        SearchResponse searchResponse = new SearchResponse( searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[] {}, clusters );
-        return searchResponse;
+        return new SearchResponse( searchResponseSections, "", 1, 1, 0, 8, new ShardSearchFailure[] {}, clusters );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/AlphaKeyServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/AlphaKeyServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import java.net.URI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,7 +23,6 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.search.api.model.response.AlphaKeyResponse;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AlphaKeyServiceTest {
 
     @InjectMocks
@@ -66,7 +64,9 @@ class AlphaKeyServiceTest {
     @DisplayName("Test alpha key response not returned due to rest client exception")
     void testNoResponseReturnedDueToException() {
         when(mockEnvironmentReader.getMandatoryString(anyString())).thenReturn(URL);
-        when(mockRestTemplate.getForObject(any(), eq(AlphaKeyResponse.class))).thenThrow(RestClientException.class);
+        when(mockRestTemplate.getForObject(any(), eq(AlphaKeyResponse.class)))
+                .thenThrow(new RestClientException("error"));
+
         URI uri = UriComponentsBuilder.fromUriString(URL)
                 .queryParam("name", CORPORATE_NAME)
                 .build()

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/advanced/TestAdvancedSearchDeleteService.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/advanced/TestAdvancedSearchDeleteService.java
@@ -1,12 +1,9 @@
 package uk.gov.companieshouse.search.api.service.delete.advanced;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.rest.RestStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TestAdvancedSearchDeleteService {
+ class TestAdvancedSearchDeleteService {
     @Mock
     private ConfiguredIndexNamesProvider indices;
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/alphabetical/AlphabeticalSearchDeleteServiceTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class AlphabeticalSearchDeleteServiceTest {
+ class AlphabeticalSearchDeleteServiceTest {
 
     private static final String INDEX = "alphabetical_search";
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteRequestServiceTest.java
@@ -16,10 +16,9 @@ import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 @ExtendWith(MockitoExtension.class)
 class PrimarySearchDeleteRequestServiceTest {
 
-    private final String INDEX = "primary_search2";
-    private final String TYPE = "primary_search";
-    private final String OFFICER_ID = "officerId";
-    private final String PRIMARY_SEARCH_TYPE = "disqualified-officer";
+    private static final String INDEX = "primary_search2";
+    private static final String OFFICER_ID = "officerId";
+    private static final String PRIMARY_SEARCH_TYPE = "disqualified-officer";
 
     @Mock
     private ConfiguredIndexNamesProvider indices;
@@ -38,6 +37,5 @@ class PrimarySearchDeleteRequestServiceTest {
 
         assertEquals(OFFICER_ID, request.id());
         assertEquals(INDEX, request.index());
-        assertEquals(TYPE, request.type());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/delete/primary/PrimarySearchDeleteServiceTest.java
@@ -8,7 +8,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.index.shard.ShardId;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -88,7 +87,6 @@ class PrimarySearchDeleteServiceTest {
 
     @Test
     void testDeleteCompanyByNumber_Success() throws IOException {
-        String companyNumber = "12345678";
         when(indices.primary()).thenReturn("primary_search");
 
         // Stubbing the delete method to return a mock DeleteResponse
@@ -103,7 +101,6 @@ class PrimarySearchDeleteServiceTest {
     }
     @Test
     void testDeleteCompanyByNumber_IOException() throws IOException {
-        String companyNumber = "12345678";
         when(primarySearchRestClientService.delete(any(DeleteRequest.class))).thenThrow(IOException.class);
 
         ResponseObject response = service.deleteCompanyByNumber(companyNumber);
@@ -113,7 +110,6 @@ class PrimarySearchDeleteServiceTest {
 
     @Test
     void testDeleteCompanyByNumber_ElasticsearchException() throws IOException {
-        String companyNumber = "12345678";
         when(primarySearchRestClientService.delete(any(DeleteRequest.class))).thenThrow(ElasticsearchException.class);
 
         ResponseObject response = service.deleteCompanyByNumber(companyNumber);
@@ -123,7 +119,6 @@ class PrimarySearchDeleteServiceTest {
 
     @Test
     void testDeleteCompanyByNumber_NotFound() throws IOException {
-        String companyNumber = "12345678";
 
         // Stubbing the delete method to return a mock DeleteResponse
         DeleteResponse deleteResponse = new DeleteResponse(

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/SearchRequestUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/SearchRequestUtilTest.java
@@ -28,7 +28,7 @@ class SearchRequestUtilTest {
     @Test
     @DisplayName("Checks that the size is set to the default if size is null")
     void checkSizeSetToDefaultIfSizeIsNull() throws SizeException {
-        assertEquals(new Integer(20), SearchRequestUtils.checkResultsSize(null, 20, 50));
+        assertEquals(Integer.valueOf(20), SearchRequestUtils.checkResultsSize(null, 20, 50));
     }
 
     @Test
@@ -42,6 +42,6 @@ class SearchRequestUtilTest {
     @Test
     @DisplayName("Checks that the requested value is returned if the size param is valid")
     void checkValueIsReturnedIfSizeIsValid() throws SizeException {
-        assertEquals(new Integer(30), SearchRequestUtils.checkResultsSize(30, 20, 50));
+        assertEquals(Integer.valueOf(30), SearchRequestUtils.checkResultsSize(30, 20, 50));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchIndexServiceTest.java
@@ -52,7 +52,7 @@ class AdvancedSearchIndexServiceTest {
         advancedSearchQueryParams.setSicCodes(SIC_CODES_LIST);
 
         when(mockAdvancedSearchRequestService.getSearchResults(advancedSearchQueryParams, "request id"))
-                .thenReturn(createSearchResults(true, false));;
+                .thenReturn(createSearchResults(true, false));
         ResponseObject responseObject = searchIndexService.searchAdvanced(advancedSearchQueryParams, "request id");
 
         assertNotNull(responseObject);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/advanced/AdvancedSearchRequestServiceTest.java
@@ -83,8 +83,6 @@ class AdvancedSearchRequestServiceTest {
     @DisplayName("Test advanced search returns no results")
     void testAdvancedSearchNoResults() throws Exception{
 
-        Company company = createCompany();
-
         AdvancedSearchQueryParams advancedSearchQueryParams = new AdvancedSearchQueryParams();
 
         when(mockAdvancedSearchRequests.getCompanies(advancedSearchQueryParams, REQUEST_ID)).thenReturn(createEmptySearchHits());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchIndexServiceTest.java
@@ -36,7 +36,7 @@ class AlphabeticalSearchIndexServiceTest {
     @Mock
     private ConfiguredIndexNamesProvider indices;
 
-    private TopHit TOP_HIT;
+    private static TopHit TOP_HIT;
     private static final String REQUEST_ID = "requestId";
     private static final String CORPORATE_NAME = "corporateName";
 
@@ -120,7 +120,6 @@ class AlphabeticalSearchIndexServiceTest {
 
         links.setCompanyProfile("self");
 
-        //company.setId("id");
         company.setCompanyType("companyType");
         company.setLinks(links);
         results.add(company);

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -117,8 +117,6 @@ class AlphabeticalSearchRequestServiceTest {
             searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 1, REQUEST_ID);
 
         assertNotNull(searchResults);
-//        System.out.println("search results " + searchResults;
-        System.out.println("search results with top hit " + searchResults.getTopHit().getCompanyNumber());
         assertEquals( TOP_HIT, searchResults.getTopHit().getCompanyName());
         assertEquals(1, searchResults.getItems().size());
     }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/alphabetical/AlphabeticalSearchRequestServiceTest.java
@@ -117,6 +117,8 @@ class AlphabeticalSearchRequestServiceTest {
             searchRequestService.getAlphabeticalSearchResults(CORPORATE_NAME, null, null, 1, REQUEST_ID);
 
         assertNotNull(searchResults);
+//        System.out.println("search results " + searchResults;
+        System.out.println("search results with top hit " + searchResults.getTopHit().getCompanyNumber());
         assertEquals( TOP_HIT, searchResults.getTopHit().getCompanyName());
         assertEquals(1, searchResults.getItems().size());
     }

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -23,6 +23,8 @@ import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -206,11 +208,23 @@ class DissolvedSearchRequestServiceTest {
         assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
     }
 
-    @Test
-    @DisplayName("Test search request returns results successfully with corporate name starts with query")
-    void testDissolvedAlphabeticalCorporateNameStartsWithSuccessful() throws Exception {
 
-        SearchHits searchHits = createSearchHits(true, true, true, true);
+
+    @ParameterizedTest(name = "Search with locality={0}, postcode={1}, address={2}, corporateName={3}")
+    @CsvSource({
+            "true,  true,  true,  true",
+            "true,  false, true,  true",
+            "true,  true,  false, true",
+            "false, true,  false, true"
+    })
+    void testCategoryNameStartsWithSuccessful(
+            boolean locality,
+            boolean postcode,
+            boolean address,
+            boolean categoryName
+    ) throws Exception {
+
+        SearchHits searchHits = createSearchHits(locality, postcode, address, categoryName);
         Company topHitCompany = createCompany();
         TopHit topHit = createTopHit();
 
@@ -226,137 +240,26 @@ class DissolvedSearchRequestServiceTest {
                 .thenReturn(searchHits);
 
         when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
-
         when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
 
-        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                10)).thenReturn(searchHits);
-
-        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, 9)).thenReturn(searchHits);
-
-        SearchResults<Company> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
-
-        assertNotNull(dissolvedSearchResults);
-        assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
-        assertEquals(3, dissolvedSearchResults.getItems().size());
-        assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
-    }
-
-    @Test
-    @DisplayName("Test search request returns results successfully with corporate name starts with query when locality missing")
-    void testCorporateNameStartsWithSuccessfulMissingLocality() throws Exception {
-
-        SearchHits searchHits = createSearchHits(true, false, true, true);
-        Company topHitCompany = createCompany();
-        TopHit topHit = createTopHit();
-
-        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME)).thenReturn(createAlphaKeyResponse());
-
-        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME, 10))
                 .thenReturn(searchHits);
 
-        when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
-
-        when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
-
-        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                10)).thenReturn(searchHits);
-
-        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, 9)).thenReturn(searchHits);
-
-        SearchResults<Company> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
-
-        assertNotNull(dissolvedSearchResults);
-        assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
-        assertEquals(3, dissolvedSearchResults.getItems().size());
-        assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
-    }
-
-    @Test
-    @DisplayName("Test search request returns results successfully with corporate name starts with query when post code missing")
-    void testCorporateNameStartsWithSuccessfulMissingPostCode() throws Exception {
-
-        SearchHits searchHits = createSearchHits(true, true, false, true);
-        Company topHitCompany = createCompany();
-        TopHit topHit = createTopHit();
-
-        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME)).thenReturn(createAlphaKeyResponse());
-
-        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
+        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME, 9))
                 .thenReturn(searchHits);
 
-        when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
-
-        when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
-
-        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                10)).thenReturn(searchHits);
-
-        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, 9)).thenReturn(searchHits);
-
-        SearchResults<Company> dissolvedSearchResults = dissolvedSearchRequestService
+        // Act
+        SearchResults<Company> results = dissolvedSearchRequestService
                 .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
 
-        assertNotNull(dissolvedSearchResults);
-        assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
-        assertEquals(3, dissolvedSearchResults.getItems().size());
-        assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
+        // Assert
+        assertNotNull(results);
+        assertEquals(COMPANY_NAME, results.getTopHit().getCompanyName());
+        assertEquals(3, results.getItems().size());
+        assertEquals(DISSOLVED_ALPHABETICAL_KIND, results.getKind());
     }
 
-    @Test
-    @DisplayName("Test search request returns results successfully with corporate name starts with query when address missing")
-    void testCorporateNameStartsWithSuccessfulMissingAddress() throws Exception {
 
-        SearchHits searchHits = createSearchHits(false, true, false, true);
-        Company topHitCompany = createCompany();
-        TopHit topHit = createTopHit();
-
-        when(mockAlphaKeyService.getAlphaKeyForCorporateName(COMPANY_NAME)).thenReturn(createAlphaKeyResponse());
-
-        when(mockDissolvedSearchRequests.getBestMatchResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(createEmptySearchHits());
-
-        when(mockDissolvedSearchRequests.getCorporateNameStartsWithResponse(ORDERED_ALPHA_KEY, REQUEST_ID))
-                .thenReturn(searchHits);
-
-        when(mockElasticSearchResponseMapper.mapDissolvedResponse(any(SearchHit.class))).thenReturn(topHitCompany);
-
-        when(mockElasticSearchResponseMapper.mapDissolvedTopHit(topHitCompany)).thenReturn(topHit);
-
-        when(mockDissolvedSearchRequests.getAboveResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME,
-                10)).thenReturn(searchHits);
-
-        when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID,
-                COMPANY_NAME, 9)).thenReturn(searchHits);
-
-        SearchResults<Company> dissolvedSearchResults = dissolvedSearchRequestService
-                .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
-
-        assertNotNull(dissolvedSearchResults);
-        assertEquals(COMPANY_NAME, dissolvedSearchResults.getTopHit().getCompanyName());
-        assertEquals(3, dissolvedSearchResults.getItems().size());
-        assertEquals(DISSOLVED_ALPHABETICAL_KIND, dissolvedSearchResults.getKind());
-    }
 
     @Test
     @DisplayName("Test search request throws exception")
@@ -596,10 +499,9 @@ class DissolvedSearchRequestServiceTest {
     }
 
     private String populatePreviousCompanyNames() {
-        String previousNames = "\"previous_company_names\" : [" + "{" + "\"name\" : \"TEST COMPANY 2\","
+        return "\"previous_company_names\" : [" + "{" + "\"name\" : \"TEST COMPANY 2\","
                 + "\"ordered_alpha_key\": \"ordered_alpha_key\"," + "\"effective_from\" : \"19890101\","
                 + "\"ceased_on\" : \"19920510\"" + "}" + "],";
-        return previousNames;
     }
 
     private Company createCompany() {

--- a/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/search/dissolved/DissolvedSearchRequestServiceTest.java
@@ -210,21 +210,22 @@ class DissolvedSearchRequestServiceTest {
 
 
 
-    @ParameterizedTest(name = "Search with locality={0}, postcode={1}, address={2}, corporateName={3}")
+    @ParameterizedTest(name = "Test search request returns results successfully with " +
+            "locality={0}, postcode={1}, address={2}, corporateName={3}")
     @CsvSource({
             "true,  true,  true,  true",
             "true,  false, true,  true",
             "true,  true,  false, true",
             "false, true,  false, true"
     })
-    void testCategoryNameStartsWithSuccessful(
+    void testSearchRequestSuccessfulWhenCorporateNameStartsWith(
             boolean locality,
             boolean postcode,
             boolean address,
-            boolean categoryName
+            boolean corporateName
     ) throws Exception {
 
-        SearchHits searchHits = createSearchHits(locality, postcode, address, categoryName);
+        SearchHits searchHits = createSearchHits(locality, postcode, address, corporateName);
         Company topHitCompany = createCompany();
         TopHit topHit = createTopHit();
 
@@ -248,11 +249,9 @@ class DissolvedSearchRequestServiceTest {
         when(mockDissolvedSearchRequests.getDescendingResultsResponse(REQUEST_ID, ORDERED_ALPHA_KEY_WITH_ID, COMPANY_NAME, 9))
                 .thenReturn(searchHits);
 
-        // Act
         SearchResults<Company> results = dissolvedSearchRequestService
                 .getSearchResults(COMPANY_NAME, null, null, SIZE, REQUEST_ID);
-
-        // Assert
+        
         assertNotNull(results);
         assertEquals(COMPANY_NAME, results.getTopHit().getCompanyName());
         assertEquals(3, results.getItems().size());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/UpsertCompanyServiceTest.java
@@ -97,7 +97,6 @@ class UpsertCompanyServiceTest {
     void testAdvancedSearchUpsertIsSuccessful() throws Exception {
 
         CompanyProfileApi company = createCompany();
-        IndexRequest indexRequest = new IndexRequest("advanced_search");
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(createResponse());
         when(mockAdvancedUpsertRequestService.createUpdateRequest(
@@ -114,7 +113,6 @@ class UpsertCompanyServiceTest {
     void testAdvancedSearchUpsertIsSuccessfulNullAlphaKeyResponse() throws Exception {
 
         CompanyProfileApi company = createCompany();
-        IndexRequest indexRequest = new IndexRequest("advanced_search");
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(null);
         when(mockAdvancedUpsertRequestService.createUpdateRequest(
@@ -162,7 +160,6 @@ class UpsertCompanyServiceTest {
     void testExceptionThrownDuringAdvancedSearchUpdateRequest() throws Exception {
 
         CompanyProfileApi company = createCompany();
-        IndexRequest indexRequest = new IndexRequest("advanced_search");
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(createResponse());
         when(mockAdvancedUpsertRequestService.createUpdateRequest(
@@ -181,7 +178,6 @@ class UpsertCompanyServiceTest {
 
         CompanyProfileApi company = createCompany();
         IndexRequest indexRequest = new IndexRequest("alpha_search");
-        UpdateRequest updateRequest = new UpdateRequest("alpha_search", company.getCompanyNumber());
 
         when(mockAlphabeticalUpsertRequestService.createIndexRequest(company)).thenReturn(indexRequest);
         when(mockAlphabeticalUpsertRequestService.createUpdateRequest(
@@ -200,8 +196,6 @@ class UpsertCompanyServiceTest {
     void testExceptionThrownDuringAdvancedSearchUpsert() throws Exception {
 
         CompanyProfileApi company = createCompany();
-        IndexRequest indexRequest = new IndexRequest("advanced_search");
-        UpdateRequest updateRequest = new UpdateRequest("advanced_search", company.getCompanyNumber());
 
         when(mockAlphaKeyService.getAlphaKeyForCorporateName(anyString())).thenReturn(createResponse());
         when(mockAdvancedUpsertRequestService.createUpdateRequest(

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/advanced/AdvancedUpsertRequestServiceTest.java
@@ -96,8 +96,8 @@ class AdvancedUpsertRequestServiceTest {
 
         when(mockAdvancedSearchUpsertRequest.buildRequest(company, ORDERED_ALPHA_KEY_FIELD,
             SAME_AS_ALPHA_KEY_FIELD))
-            .thenReturn(createRequest(company, ORDERED_ALPHA_KEY_FIELD,
-                SAME_AS_ALPHA_KEY_FIELD));
+            .thenReturn(createRequest(company, ORDERED_ALPHA_KEY_FIELD
+            ));
 
         UpdateRequest updateRequest = advancedUpsertRequestService
             .createUpdateRequest(company, ORDERED_ALPHA_KEY_FIELD, SAME_AS_ALPHA_KEY_FIELD);
@@ -145,8 +145,7 @@ class AdvancedUpsertRequestServiceTest {
         return company;
     }
 
-    private XContentBuilder createRequest(CompanyProfileApi company, String orderedAlphaKey,
-                                          String orderedAlphaKeyWithID) throws Exception {
+    private XContentBuilder createRequest(CompanyProfileApi company, String orderedAlphaKey) throws Exception {
         RegisteredOfficeAddressApi registeredOfficeAddress = company.getRegisteredOfficeAddress();
         Map<String, String> links = company.getLinks();
 

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestServiceTest.java
@@ -67,7 +67,7 @@ class CompanySearchUpsertRequestServiceTest {
 
         // then
         assertEquals(COMPANY_NUMBER, request.id());
-        String expected = "update {[primary_search2][primary_search][" + COMPANY_NUMBER
+        String expected = "update {[primary_search2][_doc][" + COMPANY_NUMBER
                 + "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON
                 + "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -21,11 +21,10 @@ import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-public class DisqualifiedUpsertRequestServiceTest {
+class DisqualifiedUpsertRequestServiceTest {
 
     private static final String UPDATE_JSON = "{\"example\":\"test\"}";
     private static final String OFFICER_ID = "testid";
-    private static final String INDEX = "PRIMARY_SEARCH_INDEX";
     private static final String PRIMARY = "primary_search2";
 
     @Mock
@@ -46,7 +45,7 @@ public class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
+        String expected = "update {[primary_search2][_doc][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());
@@ -76,7 +75,7 @@ public class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
+        String expected = "update {[primary_search2][_doc][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/UpsertDisqualificationServiceTest.java
@@ -24,7 +24,7 @@ import javax.naming.ServiceUnavailableException;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-public class UpsertDisqualificationServiceTest {
+class UpsertDisqualificationServiceTest {
 
     private static final String OFFICER_ID = "officerId";
     private static final UpdateRequest request = new UpdateRequest();

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
@@ -27,7 +27,6 @@ class OfficersUpsertRequestServiceTest {
 
     private static final String UPDATE_JSON = "{\"active_count\":0,\"inactive_count\":0,\"kind\":\"searchresults#officer\",\"resigned_count\":0,\"sort_key\":\"sort key\"}";
     private static final String OFFICER_ID = "testid";
-    private static final String INDEX = "PRIMARY_SEARCH_INDEX";
     private static final String PRIMARY = "primary_search2";
 
     @Mock
@@ -58,7 +57,7 @@ class OfficersUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(appointmentList, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID
+        String expected = "update {[primary_search2][_doc][" + OFFICER_ID
                 + "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON
                 + "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());


### PR DESCRIPTION
Resolves [ASM-306](https://companieshouse.atlassian.net/browse/ASM-306)

Attempt to resolve various Sonarqube issues raised in sonar analysis including removing deprecated annotations, constructor parameters, redundant fields/annotations,  removing modifiers not required, empty statements. 

Resolving vulnerabilities highlighted in dependency-check:
Bumped versions of 

- api-sdk-java
- api-security-java
- private-api-sdk-java
- commons-lang3
- structured-logging
- environment-reader-library
- spring-boot-dependencies
- spring-boot-maven-plugin
- spring-core
- spring-security-core

Where necessary, the CVE issue no. that the update pertains to, has been documented in the POM above the dependency. 

Added exclusions for the following as no later versions were available to upgrade to: 

- commons-lang 
- sonarsource.scanner.api



[ASM-306]: https://companieshouse.atlassian.net/browse/ASM-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ