### PR TITLE
ASM-306- revert changes made to primary search upserts

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestService.java
@@ -24,6 +24,8 @@ public class CompanySearchUpsertRequestService {
 
     private final ConfiguredIndexNamesProvider indices;
 
+    private static final String TYPE = "primary_search";
+
     public CompanySearchUpsertRequestService(@Lazy ConversionService companySearchDocumentConverter,
             ObjectMapper mapper, ConfiguredIndexNamesProvider indices) {
         this.companySearchDocumentConverter = companySearchDocumentConverter;
@@ -41,7 +43,7 @@ public class CompanySearchUpsertRequestService {
 
         try {
             String jsonString = mapper.writeValueAsString(documentToBeUpserted);
-            return new UpdateRequest(indices.primary(), companyNumber)
+            return new UpdateRequest(indices.primary(), TYPE, companyNumber)
                     .docAsUpsert(true).doc(jsonString, XContentType.JSON);
         } catch (IOException e) {
             LoggingUtils.getLogger().error("Failed to update a document for company profile" + e.getMessage(), logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestService.java
@@ -52,7 +52,7 @@ public class DisqualifiedUpsertRequestService {
         }
 
         try {
-            UpdateRequest request = new UpdateRequest(indices.primary(), officerId)
+            UpdateRequest request = new UpdateRequest(indices.primary(), TYPE, officerId)
                     .docAsUpsert(true).doc(disqualifiedSearchUpsertRequest.buildRequest(officer), XContentType.JSON);
 
             LoggingUtils.getLogger().info("Attempt to upsert document if it does not exist", logMap);

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestService.java
@@ -42,7 +42,7 @@ public class OfficersUpsertRequestService {
         try {
             String jsonString = mapper.writeValueAsString(documentToBeUpserted);
 
-            return new UpdateRequest(indices.primary(), officerId)
+            return new UpdateRequest(indices.primary(), TYPE, officerId)
                     .docAsUpsert(true).doc(jsonString, XContentType.JSON);
 
         } catch (IOException ex) {

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/company/CompanySearchUpsertRequestServiceTest.java
@@ -67,7 +67,7 @@ class CompanySearchUpsertRequestServiceTest {
 
         // then
         assertEquals(COMPANY_NUMBER, request.id());
-        String expected = "update {[primary_search2][_doc][" + COMPANY_NUMBER
+        String expected = "update {[primary_search2][primary_search][" + COMPANY_NUMBER
                 + "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON
                 + "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/disqualified/DisqualifiedUpsertRequestServiceTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.search.api.service.AlphaKeyService;
 import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
 
 @ExtendWith(MockitoExtension.class)
-class DisqualifiedUpsertRequestServiceTest {
+ class DisqualifiedUpsertRequestServiceTest {
 
     private static final String UPDATE_JSON = "{\"example\":\"test\"}";
     private static final String OFFICER_ID = "testid";
@@ -45,7 +45,7 @@ class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][_doc][" + OFFICER_ID +
+        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());
@@ -75,7 +75,7 @@ class DisqualifiedUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(officer, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][_doc][" + OFFICER_ID +
+        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID +
                 "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON +
                 "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());

--- a/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/service/upsert/officers/OfficersUpsertRequestServiceTest.java
@@ -57,7 +57,7 @@ class OfficersUpsertRequestServiceTest {
         UpdateRequest request = service.createUpdateRequest(appointmentList, OFFICER_ID);
 
         assertEquals(OFFICER_ID, request.id());
-        String expected = "update {[primary_search2][_doc][" + OFFICER_ID
+        String expected = "update {[primary_search2][primary_search][" + OFFICER_ID
                 + "], doc_as_upsert[true], doc[index {[null][_doc][null], source[" + UPDATE_JSON
                 + "]}], scripted_upsert[false], detect_noop[true]}";
         assertEquals(expected, request.toString());


### PR DESCRIPTION
Work related to [ASM-306](https://companieshouse.atlassian.net/browse/ASM-306)-  Fix for issues caused by previous maintenance work on https://github.com/companieshouse/search.api.ch.gov.uk/pull/246#issue-3407043042 

Reverted changes made to company, officers, disqualification upsert services classes which removed a parameter that was still required for es6.




[ASM-306]: https://companieshouse.atlassian.net/browse/ASM-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ