### PR TITLE
ASM-306- rewrite constructor setup for es search requests classes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AbstractSearchRequest.java
@@ -24,7 +24,7 @@ public abstract class AbstractSearchRequest {
     
     abstract AbstractSearchQuery getSearchQuery();
 
-    private EnvironmentReader environmentReader;
+    protected final EnvironmentReader environmentReader;
     
     private static final String ORDERED_ALPHA_KEY_WITH_ID = "ordered_alpha_key_with_id";
 

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequests.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.search.api.elasticsearch;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.environment.EnvironmentReader;
@@ -10,18 +9,16 @@ import uk.gov.companieshouse.search.api.service.rest.impl.AlphabeticalSearchRest
 @Component
 public class AlphabeticalSearchRequests extends AbstractSearchRequest {
 
-    private AlphabeticalSearchRestClientService searchRestClient;
-
-    private AlphabeticalSearchQueries alphabeticalSearchQueries;
+    private final AlphabeticalSearchRestClientService searchRestClient;
+    private final AlphabeticalSearchQueries alphabeticalSearchQueries;
 
     private static final String INDEX = "ALPHABETICAL_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "ALPHABETICAL_SEARCH_RESULT_MAX";
 
-    @Autowired
     public AlphabeticalSearchRequests(
-        EnvironmentReader environmentReader,
-        AlphabeticalSearchRestClientService searchRestClient,
-        AlphabeticalSearchQueries alphabeticalSearchQueries
+            EnvironmentReader environmentReader,
+            AlphabeticalSearchRestClientService searchRestClient,
+            AlphabeticalSearchQueries alphabeticalSearchQueries
     ) {
         super(environmentReader);
         this.searchRestClient = searchRestClient;

--- a/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequests.java
@@ -5,7 +5,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.logging.util.DataMap;
@@ -23,13 +22,10 @@ public class DissolvedSearchRequests extends AbstractSearchRequest {
 
     private DissolvedSearchQueries searchQueries;
 
-    private EnvironmentReader environmentReader;
-
     private static final String INDEX = "DISSOLVED_SEARCH_INDEX";
     private static final String RESULTS_SIZE = "DISSOLVED_SEARCH_RESULT_MAX";
     private static final String BEST_MATCH_SEARCH_TYPE = "best-match";
 
-    @Autowired
     public DissolvedSearchRequests(
             EnvironmentReader environmentReader,
             DissolvedSearchRestClientService searchRestClient,

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/AlphabeticalSearchRequestsTest.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -43,6 +44,15 @@ class AlphabeticalSearchRequestsTest {
 
     private static final String ENV_READER_RESULT = "1";
     private static final Integer SIZE = 10;
+
+    @BeforeEach
+    void setUp() {
+        alphabeticalSearchRequests = new AlphabeticalSearchRequests(
+                mockEnvironmentReader,
+                mockSearchRestClient,
+                mockAlphabeticalSearchQueries
+        );
+    }
 
     @Test
     @DisplayName("Get best match response")

--- a/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
+++ b/src/test/java/uk/gov/companieshouse/search/api/elasticsearch/DissolvedSearchRequestsTest.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -45,6 +46,16 @@ class DissolvedSearchRequestsTest {
     private static final String ENV_READER_RESULT = "1";
     private static final Integer SIZE = 10;
     private static final Integer START_INDEX = 0;
+
+    @BeforeEach
+    void setUp() {
+        dissolvedSearchRequests = new DissolvedSearchRequests(
+                mockEnvironmentReader,
+                mockSearchRestClient,
+                mockDissolvedSearchQueries
+        );
+    }
+
 
     @Test
     @DisplayName("Get best match response")


### PR DESCRIPTION
Further work for [ASM-306](https://github.com/companieshouse/search.api.ch.gov.uk/tree/feature/ASM-306-fix-constructer-wiring-elasticsearch-requests))
There are some failing karate tests for dissolved search that are not passing on resolving the previous issue https://github.com/companieshouse/search.api.ch.gov.uk/pull/248 . Think this is potentially due to mistakes in setup after changes were made to remove the autowired annotation. 
This PR attempts to resolves issues with karate tests where an error `java.lang.NullPointerException: Cannot invoke "...EnvironmentReader.getMandatoryString(String)" because "this.environmentReader" is null] with root cause` seemed to occur 

[ASM-306]: https://companieshouse.atlassian.net/browse/ASM-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ