### PR TITLE
POC for BI-15113 - Investigate how an officer index record is created for building PSC index records (API side)

### DIFF
--- a/src/main/java/uk/gov/companieshouse/search/api/controller/PscSearchController.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/controller/PscSearchController.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.search.api.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.search.api.mapper.ApiToResponseMapper;
+import uk.gov.companieshouse.search.api.model.psc.PscSummary;
+import uk.gov.companieshouse.search.api.service.upsert.psc.UpsertPscService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+
+@RestController
+@RequestMapping(value = "/psc-search", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PscSearchController {
+
+    private static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
+    private final ApiToResponseMapper apiToResponseMapper;
+    private final UpsertPscService upsertPscService;
+    // private final ConfiguredIndexNamesProvider indices;
+
+    public PscSearchController(ApiToResponseMapper apiToResponseMapper,
+                               UpsertPscService upsertPscService,
+                               ConfiguredIndexNamesProvider indices) {
+        this.apiToResponseMapper = apiToResponseMapper;
+        this.upsertPscService = upsertPscService;
+        this.indices = indices;
+    }
+
+    @PutMapping(value = "/psc-search/psc/{psc_id}")
+    public ResponseEntity<Object> upsertPsc(@PathVariable("psc_id") String pscId,
+                                            @Valid @RequestBody PscSummary pscSummary,
+                                            @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
+        ResponseObject responseObject = upsertPscService.upsertPsc(pscSummary, pscId, requestId);
+        return apiToResponseMapper.map(responseObject);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/mapper/PscSummaryConverter.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/mapper/PscSummaryConverter.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.search.api.mapper;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.search.api.model.psc.PscSummary;
+import uk.gov.companieshouse.search.api.model.psc.PscSearchDocument;
+
+import java.util.StringJoiner;
+
+@Component
+public class PscSummaryConverter implements Converter<PscSummary, PscSearchDocument> {
+    @Override
+    public PscSearchDocument convert(PscSummary source) {
+        PscSearchDocument doc = new PscSearchDocument();
+        // Map direct fields
+        doc.setForename(source.nameElements != null ? source.nameElements.forename : null);
+        doc.setOtherForenames(source.nameElements != null ? source.nameElements.middleName : null);
+        doc.setSurname(source.nameElements != null ? source.nameElements.surname : null);
+        doc.setTitle(source.nameElements != null ? source.nameElements.title : null);
+        doc.setPersonName(source.name);
+        doc.setPersonTitleName(
+            (source.nameElements != null && source.nameElements.title != null && !source.nameElements.title.isEmpty())
+                ? source.nameElements.title + " " + source.name
+                : source.name
+        );
+        doc.setDateOfBirth(source.dateOfBirth != null ?
+            (source.dateOfBirth.year + "-" + String.format("%02d", source.dateOfBirth.month)) : null);
+        doc.setNotifiedOn(source.notifiedOn);
+        doc.setCessatedOn(source.cessatedOn);
+        doc.setNationality(source.nationality);
+        doc.setNaturesOfControl(source.naturesOfControl);
+        doc.setCountryOfResidence(source.countryOfResidence);
+        doc.setLinks(source.links);
+        // Address concatenation
+        if (source.address != null) {
+            StringJoiner joiner = new StringJoiner(", ");
+            if (source.address.premises != null) joiner.add(source.address.premises);
+            if (source.address.addressLine1 != null) joiner.add(source.address.addressLine1);
+            if (source.address.addressLine2 != null) joiner.add(source.address.addressLine2);
+            if (source.address.locality != null) joiner.add(source.address.locality);
+            if (source.address.region != null) joiner.add(source.address.region);
+            if (source.address.country != null) joiner.add(source.address.country);
+            if (source.address.postalCode != null) joiner.add(source.address.postalCode);
+            doc.setFullAddress(joiner.toString());
+        }
+        // Computed fields
+        String surname = doc.getSurname() != null ? doc.getSurname() : "";
+        String forename = doc.getForename() != null ? doc.getForename() : "";
+        String otherForenames = doc.getOtherForenames() != null ? doc.getOtherForenames() : "";
+        String wildcardKey = surname + forename + otherForenames + "2";
+        doc.setWildcardKey(wildcardKey);
+        doc.setSortKey(wildcardKey);
+        doc.setRecordType("personswithsignificantcontrol");
+        doc.setKind("searchresults#persons-with-significant-control");
+        // TODO: Set active_count, inactive_count, resigned_count, last_cessated_on as per officers logic
+        return doc;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/psc/PscSearchDocument.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/psc/PscSearchDocument.java
@@ -1,0 +1,195 @@
+package uk.gov.companieshouse.search.api.model.psc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PscSearchDocument {
+    @JsonProperty("_id")
+    private String id;
+    @JsonProperty("person_name")
+    private String personName;
+    @JsonProperty("person_title_name")
+    private String personTitleName;
+    @JsonProperty("full_address")
+    private String fullAddress;
+    @JsonProperty("forename")
+    private String forename;
+    @JsonProperty("other_forenames")
+    private String otherForenames;
+    @JsonProperty("surname")
+    private String surname;
+    @JsonProperty("title")
+    private String title;
+    @JsonProperty("date_of_birth")
+    private String dateOfBirth;
+    @JsonProperty("notified_on")
+    private String notifiedOn;
+    @JsonProperty("cessated_on")
+    private String cessatedOn;
+    @JsonProperty("last_cessated_on")
+    private String lastCessatedOn;
+    @JsonProperty("nationality")
+    private String nationality;
+    @JsonProperty("natures_of_control")
+    private List<String> naturesOfControl;
+    @JsonProperty("country_of_residence")
+    private String countryOfResidence;
+    @JsonProperty("wildcard_key")
+    private String wildcardKey;
+    @JsonProperty("sort_key")
+    private String sortKey;
+    @JsonProperty("record_type")
+    private String recordType;
+    @JsonProperty("kind")
+    private String kind;
+    @JsonProperty("links")
+    private Object links;
+    @JsonProperty("active_count")
+    private Integer activeCount;
+    @JsonProperty("inactive_count")
+    private Integer inactiveCount;
+    @JsonProperty("resigned_count")
+    private Integer resignedCount;
+    // Add any other fields needed
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+    public String getPersonName() {
+        return personName;
+    }
+    public void setPersonName(String personName) {
+        this.personName = personName;
+    }
+    public String getPersonTitleName() {
+        return personTitleName;
+    }
+    public void setPersonTitleName(String personTitleName) {
+        this.personTitleName = personTitleName;
+    }
+    public String getFullAddress() {
+        return fullAddress;
+    }
+    public void setFullAddress(String fullAddress) {
+        this.fullAddress = fullAddress;
+    }
+    public String getForename() {
+        return forename;
+    }
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+    public String getOtherForenames() {
+        return otherForenames;
+    }
+    public void setOtherForenames(String otherForenames) {
+        this.otherForenames = otherForenames;
+    }
+    public String getSurname() {
+        return surname;
+    }
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+    public String getTitle() {
+        return title;
+    }
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+    public String getNotifiedOn() {
+        return notifiedOn;
+    }
+    public void setNotifiedOn(String notifiedOn) {
+        this.notifiedOn = notifiedOn;
+    }
+    public String getCessatedOn() {
+        return cessatedOn;
+    }
+    public void setCessatedOn(String cessatedOn) {
+        this.cessatedOn = cessatedOn;
+    }
+    public String getLastCessatedOn() {
+        return lastCessatedOn;
+    }
+    public void setLastCessatedOn(String lastCessatedOn) {
+        this.lastCessatedOn = lastCessatedOn;
+    }
+    public String getNationality() {
+        return nationality;
+    }
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+    public List<String> getNaturesOfControl() {
+        return naturesOfControl;
+    }
+    public void setNaturesOfControl(List<String> naturesOfControl) {
+        this.naturesOfControl = naturesOfControl;
+    }
+    public String getCountryOfResidence() {
+        return countryOfResidence;
+    }
+    public void setCountryOfResidence(String countryOfResidence) {
+        this.countryOfResidence = countryOfResidence;
+    }
+    public String getWildcardKey() {
+        return wildcardKey;
+    }
+    public void setWildcardKey(String wildcardKey) {
+        this.wildcardKey = wildcardKey;
+    }
+    public String getSortKey() {
+        return sortKey;
+    }
+    public void setSortKey(String sortKey) {
+        this.sortKey = sortKey;
+    }
+    public String getRecordType() {
+        return recordType;
+    }
+    public void setRecordType(String recordType) {
+        this.recordType = recordType;
+    }
+    public String getKind() {
+        return kind;
+    }
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+    public Object getLinks() {
+        return links;
+    }
+    public void setLinks(Object links) {
+        this.links = links;
+    }
+    public Integer getActiveCount() {
+        return activeCount;
+    }
+    public void setActiveCount(Integer activeCount) {
+        this.activeCount = activeCount;
+    }
+    public Integer getInactiveCount() {
+        return inactiveCount;
+    }
+    public void setInactiveCount(Integer inactiveCount) {
+        this.inactiveCount = inactiveCount;
+    }
+    public Integer getResignedCount() {
+        return resignedCount;
+    }
+    public void setResignedCount(Integer resignedCount) {
+        this.resignedCount = resignedCount;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/model/psc/PscSummary.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/model/psc/PscSummary.java
@@ -1,0 +1,81 @@
+package uk.gov.companieshouse.search.api.model.psc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class PscSummary {
+    @JsonProperty("address")
+    public Address address;
+    @JsonProperty("country_of_residence")
+    public String countryOfResidence;
+    @JsonProperty("date_of_birth")
+    public DateOfBirth dateOfBirth;
+    @JsonProperty("etag")
+    public String etag;
+    @JsonProperty("identity_verification_details")
+    public IdentityVerificationDetails identityVerificationDetails;
+    @JsonProperty("kind")
+    public String kind;
+    @JsonProperty("links")
+    public Links links;
+    @JsonProperty("name")
+    public String name;
+    @JsonProperty("name_elements")
+    public NameElements nameElements;
+    @JsonProperty("nationality")
+    public String nationality;
+    @JsonProperty("natures_of_control")
+    public List<String> naturesOfControl;
+    @JsonProperty("notified_on")
+    public String notifiedOn;
+    @JsonProperty("cessated_on")
+    public String cessatedOn;
+    // Add any other fields needed
+
+    public static class Address {
+        @JsonProperty("address_line_1")
+        public String addressLine1;
+        @JsonProperty("address_line_2")
+        public String addressLine2;
+        @JsonProperty("country")
+        public String country;
+        @JsonProperty("locality")
+        public String locality;
+        @JsonProperty("postal_code")
+        public String postalCode;
+        @JsonProperty("premises")
+        public String premises;
+        @JsonProperty("region")
+        public String region;
+    }
+
+    public static class DateOfBirth {
+        @JsonProperty("month")
+        public Integer month;
+        @JsonProperty("year")
+        public Integer year;
+    }
+
+    public static class IdentityVerificationDetails {
+        @JsonProperty("appointment_verification_end_on")
+        public String appointmentVerificationEndOn;
+        @JsonProperty("appointment_verification_start_on")
+        public String appointmentVerificationStartOn;
+    }
+
+    public static class Links {
+        @JsonProperty("self")
+        public String self;
+    }
+
+    public static class NameElements {
+        @JsonProperty("forename")
+        public String forename;
+        @JsonProperty("middle_name")
+        public String middleName;
+        @JsonProperty("surname")
+        public String surname;
+        @JsonProperty("title")
+        public String title;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/psc/PscUpsertRequestService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/psc/PscUpsertRequestService.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.search.api.service.upsert.psc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.psc.PscSummary;
+import uk.gov.companieshouse.search.api.model.psc.PscSearchDocument;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+
+@Service
+public class PscUpsertRequestService {
+
+    private static final String TYPE = "primary_search";
+    private final ConversionService conversionService;
+    private final ObjectMapper mapper;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public PscUpsertRequestService(@Lazy ConversionService conversionService, ObjectMapper mapper,
+                                   ConfiguredIndexNamesProvider indices) {
+        this.conversionService = conversionService;
+        this.mapper = mapper;
+        this.indices = indices;
+    }
+
+    public UpdateRequest createUpdateRequest(PscSummary pscSummary, String pscId) throws UpsertException {
+        LoggingUtils.getLogger().info("Creating update request for PSC: " + pscId);
+        PscSearchDocument documentToBeUpserted = Optional.ofNullable(conversionService.convert(pscSummary, PscSearchDocument.class))
+                .orElseThrow();
+        try {
+            String jsonString = mapper.writeValueAsString(documentToBeUpserted);
+            return new UpdateRequest(indices.primary(), TYPE, pscId)
+                    .docAsUpsert(true).doc(jsonString, XContentType.JSON);
+        } catch (IOException ex) {
+            LoggingUtils.getLogger().error(String.format("Error: failed to create update request for PSC: %s.", pscId), ex);
+            throw new UpsertException(String.format("Error: failed to create update request for PSC: %s.", pscId));
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/search/api/service/upsert/psc/UpsertPscService.java
+++ b/src/main/java/uk/gov/companieshouse/search/api/service/upsert/psc/UpsertPscService.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.search.api.service.upsert.psc;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.search.api.exception.UpsertException;
+import uk.gov.companieshouse.search.api.logging.LoggingUtils;
+import uk.gov.companieshouse.search.api.model.psc.PscSummary;
+import uk.gov.companieshouse.search.api.model.response.ResponseObject;
+import uk.gov.companieshouse.search.api.model.response.ResponseStatus;
+import uk.gov.companieshouse.search.api.service.rest.impl.PrimarySearchRestClientService;
+import uk.gov.companieshouse.search.api.util.ConfiguredIndexNamesProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+public class UpsertPscService {
+
+    private final PrimarySearchRestClientService primarySearchRestClientService;
+    private final PscUpsertRequestService pscUpsertRequestService;
+    private final ConfiguredIndexNamesProvider indices;
+
+    public UpsertPscService(PrimarySearchRestClientService primarySearchRestClientService,
+                            PscUpsertRequestService pscUpsertRequestService,
+                            ConfiguredIndexNamesProvider indices) {
+        this.primarySearchRestClientService = primarySearchRestClientService;
+        this.pscUpsertRequestService = pscUpsertRequestService;
+        this.indices = indices;
+    }
+
+    public ResponseObject upsertPsc(PscSummary pscSummary, String pscId, String requestId) {
+        Map<String, Object> logMap = LoggingUtils.setUpPrimaryOfficerSearchLogging(pscId, requestId, indices);
+        LoggingUtils.getLogger().info(String.format("Attempting upsert for PSC: %s into primary search.", pscId), logMap);
+
+        UpdateRequest updateRequest;
+        try {
+            updateRequest = pscUpsertRequestService.createUpdateRequest(pscSummary, pscId);
+        } catch (UpsertException e) {
+            LoggingUtils.getLogger().error(String.format("Error: could not process upsert for PSC: %s.", pscId), logMap);
+            return new ResponseObject(ResponseStatus.UPSERT_ERROR);
+        }
+
+        try {
+            primarySearchRestClientService.upsert(updateRequest);
+        } catch (IOException e) {
+            LoggingUtils.getLogger().error(String.format("Error: IOException when upserting PSC: %s.", pscId), logMap);
+            return new ResponseObject(ResponseStatus.SERVICE_UNAVAILABLE);
+        } catch (ElasticsearchException e) {
+            return new ResponseObject(ResponseStatus.UPDATE_REQUEST_ERROR);
+        }
+
+        LoggingUtils.getLogger().info("Processed PSC search upsert.", logMap);
+        return new ResponseObject(ResponseStatus.DOCUMENT_UPSERTED);
+    }
+}


### PR DESCRIPTION
New files added:

- PscSummary - the incoming PSC data structure
- PscSearchDocument - the Elasticsearch document for a PSC record. 
- PscSummaryConverter - Converts a PscSummary to a PscSearchDocument, handling all direct and computed field mappings 
- PscUpsertRequestService - Uses the converter to build an Elasticsearch UpdateRequest for a PSC record, serialising the PscSearchDocument to json 
- UpsertPscService - Calls PscUpsertRequestService to build the request
- PscSearchController Exposes endpoint (PUT /psc-search/psc/{psc_id}) to accept PSC upsert requests.