### PR TITLE
ASM-2211/2254: Bump SDK dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 
     <properties>
         <java.version>11</java.version>
-        <api-sdk-java.version>4.3.40</api-sdk-java.version>
+        <api-sdk-java.version>6.6.20</api-sdk-java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>1.4.5</api-helper-java.version>
         <api-security-java.version>0.4.6</api-security-java.version>
-        <private-api-sdk-java.version>2.0.412</private-api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.6</private-api-sdk-java.version>
 
         <!-- Elastic Search -->
         <elasticsearch.version>7.4.0</elasticsearch.version>


### PR DESCRIPTION
Intended to uplift SDK versions to resolve CompanyProfileApi mismatch in alphabetical/advanced search consumers