### PR TITLE
ASM-2254: Bump private-api-sdk-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
         <api-helper-java.version>3.0.1</api-helper-java.version>
         <api-security-java.version>2.0.14</api-security-java.version>
-        <private-api-sdk-java.version>4.0.388</private-api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.6</private-api-sdk-java.version>
 
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <assertj-core.version>3.27.7</assertj-core.version>


### PR DESCRIPTION
Intended to uplift private SDK version to resolve CompanyProfileApi mismatch in alphabetical/advanced search consumers