### PR TITLE
Remove api-sdk-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 
     <properties>
         <java.version>21</java.version>
-        <api-sdk-java.version>6.4.4</api-sdk-java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <start-class>uk.gov.companieshouse.search.api.SearchApiApplication</start-class>
@@ -227,13 +226,6 @@
             <artifactId>environment-reader-library</artifactId>
             <version>${environment-reader-library.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-java</artifactId>
-            <version>${api-sdk-java.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>private-api-sdk-java</artifactId>


### PR DESCRIPTION
Remove no longer necessary api-sdk-java as it is conflicting with the private-api-sdk-java's CompanyProfileApi import.